### PR TITLE
Add cluster-level synthesis file lists for tapeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,15 @@ sw: # In Occamy Docker
 rtl: # In SNAX Docker
 	make -C ./target/rtl/ rtl CFG_OVERRIDE=$(CFG)
 
+###################
+# Tapeout targets #
+###################
+
+# Generating filelist per cluster
+# Needed for a per-cluster synthesis
+gen-syn-flist:
+	make -C ./target/tapeout/ syn-gen-list CFG_OVERRIDE=$(CFG)
+
 # FPGA Workflow
 occamy_system_vivado_preparation: # In SNAX Docker
 	make -C ./target/fpga/ define_defines_includes_no_simset.tcl

--- a/target/tapeout/Makefile
+++ b/target/tapeout/Makefile
@@ -8,11 +8,11 @@ MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MKFILE_DIR  := $(dir $(MKFILE_PATH))
 ROOT        := $(MKFILE_DIR)../..
 BENDER      := bender
-SNITCH_ROOT := $(shell $(BENDER) path snitch_cluster)
+SNAX_ROOT   := $(shell $(BENDER) path snitch_cluster)
 
-OCCAMYGEN  ?= $(ROOT)/util/occamygen/occamygen.py
+HEMAIA_UTIL ?= $(ROOT)/util/hemaia/util.py
 
-TARGET_RTL			 ?= $(ROOT)/target/rtl
+TARGET_RTL  ?= $(ROOT)/target/rtl
 
 #######################
 # Config prerequisite #
@@ -45,10 +45,11 @@ FORCE:
 ########################
 
 syn-gen-list:
-	@$(OCCAMYGEN) --cfg $(CFG) --outdir ${MKFILE_DIR} --cluster-only-flist ${SNITCH_ROOT}
+	@$(HEMAIA_UTIL) --cfg_path $(CFG) --snax-path $(SNAX_ROOT) \
+		--outdir ${MKFILE_DIR} --cluster-flist
 
 debug-info:
-	@echo "SNITCH ROOT: ${SNITCH_ROOT}"
+	@echo "SNAX ROOT: ${SNAX_ROOT}"
 	@echo "CFG override: ${CFG_OVERRIDE}"
 	@echo "Makefile path: ${MKFILE_PATH}"
 	@echo "Makefile dir: ${MKFILE_DIR}"

--- a/target/tapeout/Makefile
+++ b/target/tapeout/Makefile
@@ -1,0 +1,55 @@
+
+
+##########################
+# Default configurations #
+##########################
+
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+MKFILE_DIR  := $(dir $(MKFILE_PATH))
+ROOT        := $(MKFILE_DIR)../..
+BENDER      := bender
+SNITCH_ROOT := $(shell $(BENDER) path snitch_cluster)
+
+OCCAMYGEN  ?= $(ROOT)/util/occamygen/occamygen.py
+
+TARGET_RTL			 ?= $(ROOT)/target/rtl
+
+#######################
+# Config prerequisite #
+#######################
+
+# If the configuration file is overriden on the command-line (through
+# CFG_OVERRIDE) and this file differs from the least recently used
+# (LRU) config, all targets depending on the configuration file have
+# to be rebuilt. This file is used to express this condition as a
+# prerequisite for other rules.
+CFG = $(TARGET_RTL)/cfg/occamy_cfg/lru.hjson
+
+$(CFG): FORCE
+	@# If the LRU config file doesn't exist, we use the default config.
+	@if [ ! -e $@ ] ; then \
+		DEFAULT_CFG="$(TARGET_RTL)/cfg/occamy_cfg/snax_two_clusters.hjson"; \
+		echo "Using default config file: $$DEFAULT_CFG"; \
+		cp $$DEFAULT_CFG $@; \
+	fi
+	@# If a config file is provided on the command-line 
+	@# then we override the LRU file with it
+	@if [ $(CFG_OVERRIDE) ] ; then \
+		echo "Overriding config file with: $(CFG_OVERRIDE)"; \
+		cp $(CFG_OVERRIDE) $@; \
+	fi
+FORCE:
+
+########################
+# Generating Filelists #
+########################
+
+syn-gen-list:
+	@$(OCCAMYGEN) --cfg $(CFG) --outdir ${MKFILE_DIR} --cluster-only-flist ${SNITCH_ROOT}
+
+debug-info:
+	@echo "SNITCH ROOT: ${SNITCH_ROOT}"
+	@echo "CFG override: ${CFG_OVERRIDE}"
+	@echo "Makefile path: ${MKFILE_PATH}"
+	@echo "Makefile dir: ${MKFILE_DIR}"
+

--- a/util/hemaia/util.py
+++ b/util/hemaia/util.py
@@ -79,37 +79,38 @@ def hemaia_util():
     if 'clusters' in occamy_cfg:
         clusters = occamy_cfg['clusters']
         cluster_cfgs = []
+        cluster_cfg_paths = []
         for cluster in clusters:
             cluster_cfg_path = os.path.dirname(parsed_args.cfg_path) + \
                 "/../cluster_cfg/" + cluster + ".hjson"
+            cluster_cfg_paths.append(cluster_cfg_path)
             cluster_cfgs.append(get_config(cluster_cfg_path))
     else:
         raise Exception("No clusters found in the hemaia json file")
-
-    # For generating filelists for each cluster
-    # These filelists are specific for synthesis only
-    if parsed_args.cluster_flist:
-        print("Generate filelist for each cluster only.")
-        for cluster in occamy_cfg['clusters']:
-            cfg_str = f"cfg/{cluster}.hjson"
-            generate_cluster_syn_flist(cfg_str,
-                                       parsed_args.snax_path,
-                                       parsed_args.outdir)
-
     if cluster_cfgs.__len__() == 0:
         raise Exception("The number of cluster is 0")
 
-    # The remaining part is related to different functions
+    # The remaining part is the region for the util functions
     # Available variables:
     # - occamy_cfg: The main configuration file
+    # - cluster_cfg_paths: The paths to the cluster configurations in a list
     # - cluster_cfgs: The parsed cluster configurations in a list
 
+    # For printing out the cluster names and generate targets
     if parsed_args.print_clusters:
         for cluster_cfg in cluster_cfgs:
             print(cluster_cfg['cluster']['name'] + " ", end="")
         print()
         return
-
+    
+    # For generating filelists for each cluster
+    # These filelists are specific for synthesis only
+    if parsed_args.cluster_flist:
+        print("Generate filelist for each cluster only.")
+        for cluster_cfg_path in cluster_cfg_paths:
+            generate_cluster_syn_flist(cluster_cfg_path,
+                                       parsed_args.snax_path,
+                                       parsed_args.outdir)
 
 if __name__ == "__main__":
     hemaia_util()

--- a/util/occamygen/occamy.py
+++ b/util/occamygen/occamy.py
@@ -9,6 +9,7 @@ from jsonref import JsonRef
 sys.path.append(str(Path(__file__).parent / '../../deps/snitch_cluster/util/clustergen'))
 from cluster import Generator, PMA, PMACfg, SnitchCluster, clog2  # noqa: E402
 import subprocess
+import os
 
 def read_json_file(file):
     try:
@@ -81,6 +82,17 @@ def get_cluster_cfg_list(occamy_cfg, cluster_cfg_dir):
 def generate_snitch(cluster_cfg_dir, snitch_path):
     for cfg in cluster_cfg_dir:
         subprocess.call(f"make -C {snitch_path}/target/snitch_cluster CFG_OVERRIDE={cfg} rtl-gen", shell=True)
+
+# For generating cluster synthesis filelists
+def generate_cluster_syn_flist(cluster_cfg_dir, snitch_path, outdir):
+    for cfg in cluster_cfg_dir:
+        config_name = os.path.splitext(os.path.basename(os.path.normpath(cfg)))[0]
+        subprocess.call(f"make -C {snitch_path}/target/snitch_cluster \
+                        CFG_OVERRIDE={cfg} \
+                        MEM_TYPE=exclude_tcsram \
+                        SYN_FLIST={config_name}.tcl \
+                        SYN_BUILDDIR={outdir} \
+                        gen-syn", shell=True)
 
 def generate_wrappers(cluster_generators,out_dir):
     for cluster_generator in cluster_generators:

--- a/util/occamygen/occamy.py
+++ b/util/occamygen/occamy.py
@@ -83,17 +83,6 @@ def generate_snitch(cluster_cfg_dir, snitch_path):
     for cfg in cluster_cfg_dir:
         subprocess.call(f"make -C {snitch_path}/target/snitch_cluster CFG_OVERRIDE={cfg} rtl-gen", shell=True)
 
-# For generating cluster synthesis filelists
-def generate_cluster_syn_flist(cluster_cfg_dir, snitch_path, outdir):
-    for cfg in cluster_cfg_dir:
-        config_name = os.path.splitext(os.path.basename(os.path.normpath(cfg)))[0]
-        subprocess.call(f"make -C {snitch_path}/target/snitch_cluster \
-                        CFG_OVERRIDE={cfg} \
-                        MEM_TYPE=exclude_tcsram \
-                        SYN_FLIST={config_name}.tcl \
-                        SYN_BUILDDIR={outdir} \
-                        gen-syn", shell=True)
-
 def generate_wrappers(cluster_generators,out_dir):
     for cluster_generator in cluster_generators:
         cluster_name = cluster_generator.cfg["name"]

--- a/util/occamygen/occamy.py
+++ b/util/occamygen/occamy.py
@@ -9,7 +9,6 @@ from jsonref import JsonRef
 sys.path.append(str(Path(__file__).parent / '../../deps/snitch_cluster/util/clustergen'))
 from cluster import Generator, PMA, PMACfg, SnitchCluster, clog2  # noqa: E402
 import subprocess
-import os
 
 def read_json_file(file):
     try:

--- a/util/occamygen/occamygen.py
+++ b/util/occamygen/occamygen.py
@@ -17,7 +17,7 @@ from jsonref import JsonRef
 
 from mako.template import Template
 
-from occamy import check_occamy_cfg, get_cluster_generators, generate_wrappers, generate_memories, get_cluster_cfg_list, generate_snitch, generate_cluster_syn_flist
+from occamy import check_occamy_cfg, get_cluster_generators, generate_wrappers, generate_memories, get_cluster_cfg_list, generate_snitch
 
 sys.path.append(str(pathlib.Path(__file__).parent / '../'))
 from solder import solder, device_tree, util  # noqa: E402
@@ -552,9 +552,6 @@ def main():
     parser.add_argument("--chip",
                         metavar="CHIP_TOP",
                         help="(Optional) Chip Top-level")
-    parser.add_argument("--cluster-only-flist",
-                        metavar="TAEPOUT",
-                        help="Flag for generating for generating cluster specific flists only.")
     parser.add_argument("--graph", "-g", metavar="DOT")
     parser.add_argument("--memories", "-m", action="store_true")
     parser.add_argument("--wrapper", "-w", action="store_true")
@@ -616,11 +613,6 @@ def main():
     if args.snitch:
         print(cluster_cfg_list)
         generate_snitch(cluster_cfg_list, args.snitch)
-
-    # For generating filelists for each cluster
-    if args.cluster_only_flist:
-        print("Generate filelist for each cluster only.")
-        generate_cluster_syn_flist(cluster_cfg_list, args.cluster_only_flist, outdir)
 
     if args.wrapper:
         generate_wrappers(cluster_generators,outdir)

--- a/util/occamygen/occamygen.py
+++ b/util/occamygen/occamygen.py
@@ -17,7 +17,7 @@ from jsonref import JsonRef
 
 from mako.template import Template
 
-from occamy import check_occamy_cfg, get_cluster_generators, generate_wrappers, generate_memories, get_cluster_cfg_list, generate_snitch
+from occamy import check_occamy_cfg, get_cluster_generators, generate_wrappers, generate_memories, get_cluster_cfg_list, generate_snitch, generate_cluster_syn_flist
 
 sys.path.append(str(pathlib.Path(__file__).parent / '../'))
 from solder import solder, device_tree, util  # noqa: E402
@@ -552,6 +552,9 @@ def main():
     parser.add_argument("--chip",
                         metavar="CHIP_TOP",
                         help="(Optional) Chip Top-level")
+    parser.add_argument("--cluster-only-flist",
+                        metavar="TAEPOUT",
+                        help="Flag for generating for generating cluster specific flists only.")
     parser.add_argument("--graph", "-g", metavar="DOT")
     parser.add_argument("--memories", "-m", action="store_true")
     parser.add_argument("--wrapper", "-w", action="store_true")
@@ -613,6 +616,11 @@ def main():
     if args.snitch:
         print(cluster_cfg_list)
         generate_snitch(cluster_cfg_list, args.snitch)
+
+    # For generating filelists for each cluster
+    if args.cluster_only_flist:
+        print("Generate filelist for each cluster only.")
+        generate_cluster_syn_flist(cluster_cfg_list, args.cluster_only_flist, outdir)
 
     if args.wrapper:
         generate_wrappers(cluster_generators,outdir)


### PR DESCRIPTION
This PR adds the generation for file lists per cluster.

Major TODO:
- [x] Create and add makefile for tapeout target
- [x] Create and add into the `occamygen` and `occamy` the call functions for generating the filelists
- [x] Modify top-level Makefile
- [x] Re-base and modify on top of PR #20 