### PR TITLE
Automatic simulation for chips not residing position zero

### DIFF
--- a/target/rtl/cfg/occamy_cfg/hemaia.hjson
+++ b/target/rtl/cfg/occamy_cfg/hemaia.hjson
@@ -5,7 +5,9 @@
     remote_quadrants: [],
     // Multi-chip configuration
     hemaia_multichip: {
-      chip_id_width: 8
+      chip_id_width: 8, 
+      single_chip: true,
+      single_chip_id: 0
     }
     addr_width: 48,
     data_width: 64,

--- a/target/rtl/cfg/occamy_cfg/hemaia_two_clusters.hjson
+++ b/target/rtl/cfg/occamy_cfg/hemaia_two_clusters.hjson
@@ -5,7 +5,9 @@
     remote_quadrants: [],
     // Multi-chip configuration
     hemaia_multichip: {
-      chip_id_width: 8
+      chip_id_width: 8, 
+      single_chip: true,
+      single_chip_id: 1
     }
     addr_width: 48,
     data_width: 64,

--- a/target/rtl/test/bootdata.cc.tpl
+++ b/target/rtl/test/bootdata.cc.tpl
@@ -6,16 +6,21 @@
 
 namespace sim {
 
-const BootData BOOTDATA = {.boot_addr = ${boot_addr},
+<%
+    mem_offset = single_chip_id << (addr_width - chip_id_width)
+%>
+
+const BootData BOOTDATA = {.boot_addr = ${hex(boot_addr + mem_offset)},
                            .core_count = ${core_count},
                            .hartid_base = ${hart_id_base},
-                           .tcdm_start = ${tcdm_start},
-                           .tcdm_size = ${tcdm_size},
-                           .tcdm_offset = ${tcdm_offset},
-                           .global_mem_start = ${global_mem_start},
-                           .global_mem_end = ${global_mem_end},
+                           .tcdm_start = ${hex(tcdm_start + mem_offset)},
+                           .tcdm_size = ${hex(tcdm_size)},
+                           .tcdm_offset = ${hex(tcdm_offset)},
+                           .global_mem_start = ${hex(global_mem_start + mem_offset)},
+                           .global_mem_end = ${hex(global_mem_end + mem_offset)},
                            .cluster_count = ${cluster_count},
                            .s1_quadrant_count = ${s1_quadrant_count},
-                           .clint_base = ${clint_base}};
+                           .clint_base = ${hex(clint_base + mem_offset)}
+                        };
 
 }  // namespace sim

--- a/target/rtl/test/bootrom.cc
+++ b/target/rtl/test/bootrom.cc
@@ -1,0 +1,8 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+asm(".global tb_bootrom_start \n"
+    ".global tb_bootrom_end \n"
+    "tb_bootrom_start: .incbin \"bootrom.bin\" \n"
+    "tb_bootrom_end: \n");

--- a/target/rtl/test/common_lib.cc
+++ b/target/rtl/test/common_lib.cc
@@ -1,0 +1,59 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+#include <iostream>
+
+#include "sim.hh"
+#include "tb_lib.hh"
+
+namespace sim {
+
+// Bootloader
+extern "C" {
+extern const uint8_t tb_bootrom_start;
+extern const uint8_t tb_bootrom_end;
+}
+
+// The global memory all memory ports write into.
+GlobalMemory MEM;
+
+// Override HTIF to populate bootloader with system specification and entry
+// symbol.
+void Sim::start() {
+    htif_t::start();
+
+    // Write the bootloader into memory.
+    size_t bllen = (&tb_bootrom_end - &tb_bootrom_start);
+    MEM.write(BOOTDATA.boot_addr, bllen, &tb_bootrom_start, nullptr);
+    std::cout << "[fesvr] Wrote " << bllen << " bytes of bootrom to 0x"
+              << std::hex << BOOTDATA.boot_addr << "\n";
+
+    // Write the entry point of the binary to the last word in the bootloader
+    // (which is a placeholder for this data).
+    uint32_t e = get_entry_point();
+    size_t ep = BOOTDATA.boot_addr + bllen - 4;
+    MEM.write(ep, 4, reinterpret_cast<const uint8_t *>(&e), nullptr);
+    std::cout << "[fesvr] Wrote entry point 0x" << std::hex << e
+              << " to bootloader slot 0x" << ep << "\n";
+
+    // Write the boot data to the end of the bootloader. This address will be
+    // passed to the binary in register a1.
+    size_t bdlen = sizeof(BootData);
+    size_t bdp = BOOTDATA.boot_addr + bllen;
+    MEM.write(bdp, bdlen, reinterpret_cast<const uint8_t *>(&BOOTDATA),
+              nullptr);
+    std::cout << "[fesvr] Wrote " << bdlen << " bytes of bootdata to 0x"
+              << std::hex << bdp << "\n";
+}
+
+void Sim::read_chunk(addr_t taddr, size_t len, void *dst) {
+    MEM.read(taddr, len, reinterpret_cast<uint8_t *>(dst));
+}
+
+void Sim::write_chunk(addr_t taddr, size_t len, const void *src) {
+    uint8_t strb[8] = {1, 1, 1, 1, 1, 1, 1, 1};
+    MEM.write(taddr, len, reinterpret_cast<const uint8_t *>(src), strb);
+}
+
+}  // namespace sim

--- a/target/rtl/test/ipc.cc
+++ b/target/rtl/test/ipc.cc
@@ -1,0 +1,127 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+#include "ipc.hh"
+#include "tb_lib.hh"
+
+void* IpcIface::ipc_thread_handle(void* in) {
+    ipc_targs_t* targs = (ipc_targs_t*)in;
+    // Open FIFOs
+    FILE* tx = fopen(targs->tx, "rb");
+    FILE* rx = fopen(targs->rx, "wb");
+    // Prepare data and full-strobe array
+    uint8_t buf_data[IPC_BUF_SIZE];
+    uint8_t buf_strb[IPC_BUF_SIZE_STRB];
+    std::fill_n(buf_strb, IPC_BUF_SIZE_STRB, 0xFF);
+    // Handle commands
+    ipc_op_t op;
+
+    while (1) {
+        if (!fread(&op, sizeof(ipc_op_t), 1, tx)) {
+            if (feof(tx)) {
+                printf(
+                    "[IPC] All messages read. Closing FIFOs and joining main "
+                    "thread.\n");
+                break;
+            }
+        } else {
+            switch (op.opcode) {
+                case Read:
+                    // Read full blocks until one full block or less left
+                    printf("[IPC] Read from 0x%x len 0x%x ...\n", op.addr,
+                           op.len);
+                    for (uint64_t i = op.len; i > IPC_BUF_SIZE;
+                         i -= IPC_BUF_SIZE) {
+                        sim::MEM.read(op.addr, IPC_BUF_SIZE, buf_data);
+                        fwrite(buf_data, IPC_BUF_SIZE, 1, rx);
+                        op.addr += IPC_BUF_SIZE;
+                        op.len -= IPC_BUF_SIZE;
+                    }
+                    sim::MEM.read(op.addr, op.len, buf_data);
+                    fwrite(buf_data, op.len, 1, rx);
+                    fflush(rx);
+                    break;
+                case Write:
+                    // Write full blocks until one full block or less left
+                    printf("[IPC] Write to 0x%x len %d ...\n", op.addr, op.len);
+                    for (uint64_t i = op.len; i > IPC_BUF_SIZE;
+                         i -= IPC_BUF_SIZE) {
+                        fread(buf_data, IPC_BUF_SIZE, 1, tx);
+                        sim::MEM.write(op.addr, IPC_BUF_SIZE, buf_data,
+                                       buf_strb);
+                        op.addr += IPC_BUF_SIZE;
+                        op.len -= IPC_BUF_SIZE;
+                    }
+                    fread(buf_data, op.len, 1, tx);
+                    sim::MEM.write(op.addr, op.len, buf_data, buf_strb);
+                    break;
+                case Poll:
+                    // Unpack 32b checking mask and expected value from length
+                    uint32_t mask = op.len & 0xFFFFFFFF;
+                    uint32_t expected = (op.len >> 32) & 0xFFFFFFFF;
+                    printf("[IPC] Poll on 0x%x mask 0x%x expected 0x%x ...\n",
+                           op.addr, mask, expected);
+                    uint32_t read;
+                    do {
+                        sim::MEM.read(op.addr, sizeof(uint32_t),
+                                      (uint8_t*)(void*)&read);
+                        nanosleep(
+                            (const struct timespec[]){{0, IPC_POLL_PERIOD_NS}},
+                            NULL);
+                    } while ((read & mask) == (expected & mask));
+                    // Send back read 32b word
+                    fwrite(&read, sizeof(uint32_t), 1, rx);
+                    fflush(rx);
+                    break;
+            }
+        }
+    }
+
+    // TX FIFO closed at other end: close both FIFOs and join main thread
+    fclose(tx);
+    fclose(rx);
+    pthread_exit(NULL);
+}
+
+// Conditionally construct IPC iff any arguments specify it
+IpcIface::IpcIface(int argc, char** argv) {
+    static constexpr char IPC_FLAG[6] = "--ipc";
+    active = false;
+    for (auto i = 1; i < argc; ++i) {
+        if (strncmp(argv[i], IPC_FLAG, strlen(IPC_FLAG)) == 0) {
+            // Check for duplicate args
+            if (active) {
+                fprintf(stderr, "[IPC] Duplicate IPC thread args: %s", argv[i]);
+                exit(IPC_ERR_DOUBLE_ARG);
+            }
+            // Parse IPC thread arguments
+            char* ipc_args = argv[i] + strlen(IPC_FLAG) + 1;
+            char* tx = strtok(ipc_args, ",");
+            char* rx = strtok(NULL, ",");
+            // Store arguments persistently
+            targs.tx = (char*)malloc(strlen(tx));
+            targs.rx = (char*)malloc(strlen(rx));
+            strcpy(targs.tx, tx);
+            strcpy(targs.rx, rx);
+            // Initialize IO thread which will handle TX, RX pipes
+            pthread_create(&thread, NULL, *ipc_thread_handle, (void*)&targs);
+            printf("[IPC] Thread launched with TX FIFO `%s`, RX FIFO `%s`\n",
+                   targs.tx, targs.rx);
+            active = true;
+        }
+    }
+}
+
+// Conditionally destroy IPC iff it is enabled
+IpcIface::~IpcIface() {
+    if (active) {
+        pthread_join(thread, NULL);
+        printf("[IPC] Thread joined\n");
+        active = false;
+        free(targs.tx);
+        free(targs.rx);
+    }
+}

--- a/target/rtl/test/ipc.hh
+++ b/target/rtl/test/ipc.hh
@@ -1,0 +1,55 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Paul Scheffler <paulsc@iis.ee.ethz.ch>
+
+#pragma once
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <algorithm>
+
+class IpcIface {
+   private:
+    static const int IPC_BUF_SIZE = 4096;
+    static const int IPC_BUF_SIZE_STRB = IPC_BUF_SIZE / 8 + 1;
+    static const int IPC_ERR_DOUBLE_ARG = 30;
+    static const long IPC_POLL_PERIOD_NS = 100000L;
+
+    // Possible IPC operations
+    enum ipc_opcode_e {
+        Read = 0,
+        Write = 1,
+        Poll = 2,
+    };
+
+    // Operations are 3 doubles, followed by data streams in either direction
+    typedef struct {
+        uint64_t opcode;
+        uint64_t addr;
+        uint64_t len;
+    } ipc_op_t;
+
+    // Args passed to IPC thread
+    typedef struct {
+        char* tx;
+        char* rx;
+    } ipc_targs_t;
+
+    // Thread to asynchronously handle FIFOs
+    ipc_targs_t targs;
+    pthread_t thread;
+    bool active;
+
+    static void* ipc_thread_handle(void* in);
+
+   public:
+    IpcIface(int argc, char** argv);
+    ~IpcIface();
+};

--- a/target/rtl/test/rtl_lib.cc
+++ b/target/rtl/test/rtl_lib.cc
@@ -1,0 +1,148 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+#include <svdpi.h>
+#include <vpi_user.h>
+
+#include <iostream>
+#include <memory>
+
+#include "sim.hh"
+#include "tb_lib.hh"
+
+/// DPI Functions.
+extern "C" {
+/// Tick and check whether `fesvr` communication is necessary.
+int fesvr_tick();
+void fesvr_cleanup();
+void clint_tick(const svOpenArrayHandle msip);
+void tb_memory_read(long long addr, int len, const svOpenArrayHandle data);
+void tb_memory_write(long long addr, int len, const svOpenArrayHandle data,
+                     const svOpenArrayHandle strb);
+}
+
+namespace sim {
+void sim_thread_main(void *arg) { ((Sim *)arg)->main(); }
+
+Sim::Sim(int argc, char **argv) : htif_t(argc, argv), ipc(argc, argv) {
+    for (auto i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "--disable_preloading") == 0) {
+            printf("fesvr-based binary preloading disabled\n");
+            disable_preloading = true;
+        }
+    }
+    host = context_t::current();
+    target.init(sim_thread_main, this);
+    target.switch_to();
+}
+
+void Sim::idle() { host->switch_to(); }
+
+// A single tick.
+int Sim::run() {
+    host = context_t::current();
+    target.switch_to();
+    return (exit_code() << 1 | done());
+}
+
+// Host thread.
+void Sim::main() {
+    htif_t::run();
+    // HTIF has finished, just idle now.
+    while (true) {
+        idle();
+    }
+}
+
+}  // namespace sim
+
+std::unique_ptr<sim::Sim> s;
+
+int fesvr_tick() {
+    // Initialize on first tick.
+    if (s == nullptr) {
+        bool permissive_on = false;
+
+        s_vpi_vlog_info info;
+        if (!vpi_get_vlog_info(&info)) abort();
+
+        std::vector<std::string> htif_args;
+
+        // sanitize arguments
+        for (int i = 1; i < info.argc; i++) {
+            if (strcmp(info.argv[i], "+permissive") == 0) {
+                permissive_on = true;
+            }
+
+            // remove any two double pluses at the beginning (those are target
+            // arguments)
+            if (info.argv[i][0] == '+' && info.argv[i][1] == '+' &&
+                strlen(info.argv[i]) > 3) {
+                for (int j = 0; j < strlen(info.argv[i]) - 1; j++) {
+                    info.argv[i][j] = info.argv[i][j + 2];
+                }
+            }
+
+            if (!permissive_on) {
+                htif_args.push_back(info.argv[i]);
+            }
+
+            if (strcmp(info.argv[i], "+permissive-off") == 0) {
+                permissive_on = false;
+            }
+        }
+
+        // convert vector to argc and argv
+        int argc = htif_args.size() + 1;
+        char *argv[argc];
+        argv[0] = (char *)"htif";
+
+        for (unsigned int i = 0; i < htif_args.size(); i++) {
+            argv[i + 1] = (char *)htif_args[i].c_str();
+        }
+
+        s = std::make_unique<sim::Sim>(argc, (char **)argv);
+    }
+
+    return s->run();
+}
+
+// Destroy simulation object, synchronizes the IPC thread
+void fesvr_cleanup() { s.reset(); }
+
+// DPI calls.
+void tb_memory_read(long long addr, int len, const svOpenArrayHandle data) {
+    // std::cout << "[TB] Read " << std::hex << addr << std::dec << " (" << len
+    //           << " bytes)\n";
+    void *data_ptr = svGetArrayPtr(data);
+    assert(data_ptr);
+    sim::MEM.read(addr, len, (uint8_t *)data_ptr);
+}
+
+void tb_memory_write(long long addr, int len, const svOpenArrayHandle data,
+                     const svOpenArrayHandle strb) {
+    // std::cout << "[TB] Write " << std::hex << addr << std::dec << " (" << len
+    //           << " bytes)\n";
+    const void *data_ptr = svGetArrayPtr(data);
+    const void *strb_ptr = svGetArrayPtr(strb);
+    assert(data_ptr);
+    assert(strb_ptr);
+    sim::MEM.write(addr, len, (const uint8_t *)data_ptr,
+                   (const uint8_t *)strb_ptr);
+}
+
+const long long clint_addr = sim::BOOTDATA.clint_base;
+const long num_cores = sim::BOOTDATA.core_count;
+
+void clint_tick(const svOpenArrayHandle msip) {
+    uint8_t *msip_ptr = (uint8_t *)svGetArrayPtr(msip);
+    assert(msip_ptr);
+    uint32_t read_val;
+    for (int i = 0; i < num_cores; i++) {
+        if (i % 32 == 0)
+            sim::MEM.read(clint_addr + i / 32, sizeof(uint32_t),
+                          (uint8_t *)&read_val);
+        msip_ptr[i] = (read_val & (1 << (i % 32))) != 0 ? 1 : 0;
+    }
+}

--- a/target/rtl/test/sim.hh
+++ b/target/rtl/test/sim.hh
@@ -1,0 +1,57 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+#pragma once
+#include <fesvr/context.h>
+#include <fesvr/htif.h>
+
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <unordered_map>
+#include <vector>
+
+#include "ipc.hh"
+
+namespace sim {
+using namespace std::chrono_literals;
+
+// Simulation object with `fesvr` support.
+struct Sim : htif_t {
+    Sim(int argc, char **argv);
+
+    virtual void start();
+
+    int run();
+    void main();
+
+    // HTIF overrides. Calls into the global memory.
+    void read_chunk(addr_t taddr, size_t len, void *dst);
+    void write_chunk(addr_t taddr, size_t len, const void *src);
+    bool is_address_preloaded(addr_t taddr, size_t len) override {
+        return disable_preloading;
+    }
+
+    void idle();
+
+    // Force alignment to 8 byte.
+    size_t chunk_align() { return 8; }
+    // Force chunk size to 8 byte.
+    size_t chunk_max_size() { return 8; }
+
+    void reset() {}
+
+   private:
+    context_t *host;
+    context_t target;
+    bool vlt_vcd = false;
+    bool disable_preloading = false;
+    IpcIface ipc;
+};
+
+void sim_thread_main(void *arg);
+
+}  // namespace sim

--- a/target/rtl/test/tb_bin.cc
+++ b/target/rtl/test/tb_bin.cc
@@ -1,0 +1,23 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+#include <printf.h>
+
+#include "sim.hh"
+
+int main(int argc, char **argv, char **env) {
+    // Write binary path to logs/binary for the `make annotate` target
+    FILE *fd;
+    fd = fopen("logs/.rtlbinary", "w");
+    if (fd != NULL && argc >= 2) {
+        fprintf(fd, "%s\n", argv[1]);
+        fclose(fd);
+    } else {
+        fprintf(stderr,
+                "Warning: Failed to write binary name to logs/.rtlbinary\n");
+    }
+
+    auto sim = std::make_unique<sim::Sim>(argc, argv);
+    return sim->run();
+}

--- a/target/rtl/test/tb_bin.sv
+++ b/target/rtl/test/tb_bin.sv
@@ -1,0 +1,77 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+/// RTL Top-level for `fesvr` simulation.
+module tb_bin;
+  import "DPI-C" function int fesvr_tick();
+  import "DPI-C" function void fesvr_cleanup();
+
+  // This can't have an explicit type, otherwise the simulation will not advance
+  // for whatever reason.
+  // verilog_lint: waive explicit-parameter-storage-type
+  localparam TCK = 1ns;
+
+  logic rst_ni, clk_i;
+
+  testharness i_dut (
+    .clk_i,
+    .rst_ni
+  );
+
+  // Function to generate a random delay between min and max
+  function int random_delay(int min, int max);
+    automatic int range;
+    begin
+      if (min > max) begin
+        // Swap if min is greater than max
+        automatic int temp = min;
+        min = max;
+        max = temp;
+      end
+      range = max - min + 1;
+      return min + ($urandom % range);
+    end
+  endfunction
+
+  // Generate reset
+  initial begin
+    automatic real rst_delay;
+    rst_ni = 0;
+    rst_delay = random_delay(10,20);
+    #rst_delay;
+    rst_ni = 1;
+    rst_delay = random_delay(10,20);
+    #rst_delay;
+    rst_ni = 0;
+    rst_delay = random_delay(10,20);
+    #rst_delay;
+    rst_ni = 1;
+  end
+
+  // Generate clock
+  initial begin
+    forever begin
+      clk_i = 1;
+      #(TCK/2);
+      clk_i = 0;
+      #(TCK/2);
+    end
+  end
+
+  // Start `fesvr`
+  initial begin
+    automatic int exit_code;
+    while ((exit_code = fesvr_tick()) == 0) #200ns;
+    // Cleanup C++ simulation objects before $finish is called
+    fesvr_cleanup();
+    exit_code >>= 1;
+    if (exit_code > 0) begin
+      $error("[FAILURE] Finished with exit code %2d", exit_code);
+    end else begin
+      $info("[SUCCESS] Program finished successfully");
+    end
+    $finish;
+  end
+
+endmodule

--- a/target/rtl/test/tb_lib.hh
+++ b/target/rtl/test/tb_lib.hh
@@ -1,0 +1,134 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Author: Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
+// Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+
+#pragma once
+#include "sim.hh"
+
+namespace sim {
+
+struct GlobalMemory {
+    static constexpr size_t ADDR_SHIFT = 12;
+    static constexpr size_t PAGE_SIZE = (size_t)1 << ADDR_SHIFT;
+
+    std::unordered_map<uint64_t, std::unique_ptr<uint8_t[]>> pages;
+    std::set<uint64_t> touched;
+
+    // A mapping of host memory into Manticore memory.
+    struct Mapping {
+        uint64_t base;  // manticore memory
+        size_t size;
+        uint8_t *into;  // host memory
+    };
+    std::vector<Mapping> mappings;
+
+    uint8_t *find_mapping(uint64_t addr) const {
+        for (const auto &m : mappings) {
+            if (m.base <= addr && m.base + m.size > addr) {
+                return m.into + (addr - m.base);
+            }
+        }
+        return nullptr;
+    }
+
+    // Copy a chunk of data into memory.
+    void write(size_t addr, size_t len, const uint8_t *data,
+               const uint8_t *strb) {
+        // std::cout << "[GlobalMemory] Write " << std::hex << addr << std::dec
+        //           << " (" << len << " bytes)\n";
+        size_t end = addr + len;
+        size_t data_idx = 0;
+        while (addr < end) {
+            size_t byte_start = addr;
+            addr >>= ADDR_SHIFT;
+            auto &page = pages[addr];
+            uint64_t page_idx = addr;
+            if (!page) {
+                // std::cout << "[TB] Allocate page " << std::hex << (addr <<
+                // ADDR_SHIFT) << "\n";
+                page = std::make_unique<uint8_t[]>(PAGE_SIZE);
+                std::fill(&page[0], &page[PAGE_SIZE], 0);
+            }
+            // std::cout << "[TB] Write to page " << std::hex << (addr <<
+            // ADDR_SHIFT)
+            // << "\n";
+            addr += 1;
+            addr <<= ADDR_SHIFT;
+            size_t byte_end = std::min(addr, end);
+            bool any_changed = false;
+            for (size_t i = byte_start; i < byte_end; i++, data_idx++) {
+                if (!strb || strb[data_idx]) {
+                    // std::cout << "[TB] Write byte " << std::hex << i << " = "
+                    // << (uint32_t)data[data_idx] << "\n";
+                    auto host = find_mapping(i);
+                    if (host) {
+                        *host = data[data_idx];
+                    } else {
+                        page[i % PAGE_SIZE] = data[data_idx];
+                        any_changed = true;
+                    }
+                }
+            }
+            if (any_changed) touched.insert(page_idx);
+        }
+        std::cout << std::dec;
+    }
+
+    // Copy a chunk of data out of the memory.
+    void read(size_t addr, size_t len, uint8_t *data) {
+        // std::cout << "[GlobalMemory] Read " << std::hex << addr << std::dec
+        //           << " (" << len << " bytes)\n";
+        size_t end = addr + len;
+        size_t data_idx = 0;
+        while (addr < end) {
+            size_t byte_start = addr;
+            addr >>= ADDR_SHIFT;
+            auto &page = pages[addr];
+            // std::cout << "[TB] Read from page " << std::hex << (addr <<
+            // ADDR_SHIFT)
+            // << "\n";
+            addr += 1;
+            addr <<= ADDR_SHIFT;
+            size_t byte_end = std::min(addr, end);
+            for (size_t i = byte_start; i < byte_end; i++, data_idx++) {
+                auto host = find_mapping(i);
+                if (host) {
+                    data[data_idx] = *host;
+                } else {
+                    if (page) {
+                        // std::cout << "[TB] Read byte " << std::hex << i <<
+                        // "\n";
+                        data[data_idx] = page[i % PAGE_SIZE];
+                    } else {
+                        data[data_idx] = 0;
+                    }
+                }
+            }
+        }
+        std::cout << std::dec;
+    }
+};
+
+// The global memory all memory ports write into.
+extern GlobalMemory MEM;
+
+// The boot data generated along with the system RTL.
+struct BootData {
+    uint64_t boot_addr;
+    uint32_t core_count;
+    uint32_t hartid_base;
+    uint64_t tcdm_start;
+    uint64_t tcdm_size;
+    uint64_t tcdm_offset;
+    uint64_t global_mem_start;
+    uint64_t global_mem_end;
+    uint32_t cluster_count;
+    uint32_t s1_quadrant_count;
+    uint64_t clint_base;
+};
+extern const BootData BOOTDATA;
+
+}  // namespace sim

--- a/target/rtl/test/tb_memory_axi.sv
+++ b/target/rtl/test/tb_memory_axi.sv
@@ -1,0 +1,130 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
+// Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+
+module tb_memory_axi #(
+  /// AXI4+ATOP address width.
+  parameter int unsigned AxiAddrWidth  = 0,
+  /// AXI4+ATOP data width.
+  parameter int unsigned AxiDataWidth  = 0,
+  /// AXI4+ATOP ID width.
+  parameter int unsigned AxiIdWidth  = 0,
+  /// AXI4+ATOP User width.
+  parameter int unsigned AxiUserWidth  = 0,
+  /// Atomic memory support.
+  parameter bit unsigned ATOPSupport = 1,
+  parameter type req_t = logic,
+  parameter type rsp_t = logic
+)(
+  input  logic clk_i,
+  input  logic rst_ni,
+  input  req_t req_i,
+  output rsp_t rsp_o
+);
+
+  `include "axi/assign.svh"
+  `include "axi/typedef.svh"
+
+  `include "register_interface/typedef.svh"
+  `include "register_interface/assign.svh"
+
+  `include "common_cells/assertions.svh"
+
+  localparam int NumBytes = AxiDataWidth/8;
+  localparam int BusAlign = $clog2(NumBytes);
+
+  REG_BUS #(
+    .ADDR_WIDTH ( AxiAddrWidth ),
+    .DATA_WIDTH ( AxiDataWidth )
+  ) regb(clk_i);
+
+  AXI_BUS #(
+    .AXI_ADDR_WIDTH ( AxiAddrWidth ),
+    .AXI_DATA_WIDTH ( AxiDataWidth ),
+    .AXI_ID_WIDTH   ( AxiIdWidth   ),
+    .AXI_USER_WIDTH ( AxiUserWidth )
+  ) axi(),
+    axi_wo_atomics(),
+    axi_wo_atomics_cut();
+
+  `AXI_ASSIGN_FROM_REQ(axi, req_i)
+  `AXI_ASSIGN_TO_RESP(rsp_o, axi)
+
+  // Filter atomic operations.
+  if (ATOPSupport) begin : gen_atop_support
+    axi_riscv_atomics_wrap #(
+      .AXI_ADDR_WIDTH (AxiAddrWidth),
+      .AXI_DATA_WIDTH (AxiDataWidth),
+      .AXI_ID_WIDTH (AxiIdWidth),
+      .AXI_USER_WIDTH (AxiUserWidth),
+      .AXI_MAX_READ_TXNS (2),
+      .AXI_MAX_WRITE_TXNS (2),
+      .RISCV_WORD_WIDTH (32)
+    ) i_axi_riscv_atomics_wrap (
+      .clk_i (clk_i),
+      .rst_ni (rst_ni),
+      .slv (axi),
+      .mst (axi_wo_atomics)
+    );
+  end else begin : gen_no_atop_support
+    `AXI_ASSIGN(axi_wo_atomics, axi)
+    `ASSERT(NoAtomicOperation, axi.aw_valid & axi.aw_ready |-> (axi.aw_atop == axi_pkg::ATOP_NONE))
+  end
+
+  // Ensure the AXI interface has not feedthrough signals.
+  axi_cut_intf #(
+    .BYPASS     (1'b0),
+    .ADDR_WIDTH (AxiAddrWidth),
+    .DATA_WIDTH (AxiDataWidth),
+    .ID_WIDTH   (AxiIdWidth),
+    .USER_WIDTH (AxiUserWidth)
+  ) i_cut (
+    .clk_i (clk_i),
+    .rst_ni (rst_ni),
+    .in (axi_wo_atomics),
+    .out (axi_wo_atomics_cut)
+  );
+
+  // Convert AXI to a trivial register interface.
+  axi_to_reg_intf #(
+    .ADDR_WIDTH ( AxiAddrWidth ),
+    .DATA_WIDTH ( AxiDataWidth ),
+    .ID_WIDTH   ( AxiIdWidth   ),
+    .USER_WIDTH ( AxiUserWidth ),
+    .DECOUPLE_W ( 1            ),
+    .FULL_BW    ( 1            ),
+    .AXI_MAX_WRITE_TXNS ( 32'd128 ),
+    .AXI_MAX_READ_TXNS  ( 32'd128 )
+  ) i_axi_to_reg (
+    .clk_i,
+    .rst_ni,
+    .testmode_i ( 1'b0 ),
+    .in         ( axi_wo_atomics_cut ),
+    .reg_o      ( regb )
+  );
+
+  `REG_BUS_TYPEDEF_ALL(regbus,
+    logic [AxiAddrWidth-1:0], logic [AxiDataWidth-1:0], logic [NumBytes-1:0])
+
+  regbus_req_t regbus_req;
+  regbus_rsp_t regbus_rsp;
+
+  `REG_BUS_ASSIGN_TO_REQ(regbus_req, regb)
+  `REG_BUS_ASSIGN_FROM_RSP(regb, regbus_rsp)
+
+  tb_memory_regbus #(
+    .AddrWidth (AxiAddrWidth),
+    .DataWidth (AxiDataWidth),
+    .req_t (regbus_req_t),
+    .rsp_t (regbus_rsp_t)
+  ) i_tb_memory_regbus (
+    .clk_i,
+    .rst_ni,
+    .req_i (regbus_req),
+    .rsp_o (regbus_rsp)
+  );
+
+endmodule

--- a/target/rtl/test/tb_memory_regbus.sv
+++ b/target/rtl/test/tb_memory_regbus.sv
@@ -1,0 +1,78 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
+// Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+
+module tb_memory_regbus #(
+  /// Regbus address width.
+  parameter int unsigned AddrWidth  = 0,
+  /// Regbus data width.
+  parameter int unsigned DataWidth  = 0,
+  parameter type req_t = logic,
+  parameter type rsp_t = logic
+)(
+  input  logic clk_i,
+  input  logic rst_ni,
+  input  req_t req_i,
+  output rsp_t rsp_o
+);
+
+  `include "register_interface/assign.svh"
+
+  import "DPI-C" function void tb_memory_read(
+    input longint addr,
+    input int len,
+    output byte data[]
+  );
+  import "DPI-C" function void tb_memory_write(
+    input longint addr,
+    input int len,
+    input byte data[],
+    input bit strb[]
+  );
+
+  localparam int NumBytes = DataWidth/8;
+  localparam int BusAlign = $clog2(NumBytes);
+
+  REG_BUS #(
+    .ADDR_WIDTH ( AddrWidth ),
+    .DATA_WIDTH ( DataWidth )
+  ) regb(clk_i);
+
+  `REG_BUS_ASSIGN_FROM_REQ(regb, req_i)
+  `REG_BUS_ASSIGN_TO_RSP(rsp_o, regb)
+
+  assign regb.error = 0;
+  assign regb.ready = 1;
+
+  // Handle write requests on the register bus.
+  always_ff @(posedge clk_i) begin
+    if (rst_ni && regb.valid) begin
+      automatic byte data[NumBytes];
+      automatic bit  strb[NumBytes];
+      if (regb.write) begin
+        for (int i = 0; i < NumBytes; i++) begin
+          // verilog_lint: waive-start always-ff-non-blocking
+          data[i] = regb.wdata[i*8+:8];
+          strb[i] = regb.wstrb[i];
+          // verilog_lint: waive-start always-ff-non-blocking
+        end
+        tb_memory_write((regb.addr >> BusAlign) << BusAlign, NumBytes, data, strb);
+      end
+    end
+  end
+
+  // Handle read requests combinatorial on the register bus.
+  always_comb begin
+    if (regb.valid) begin
+      automatic byte data[NumBytes];
+      tb_memory_read((regb.addr >> BusAlign) << BusAlign, NumBytes, data);
+      for (int i = 0; i < NumBytes; i++) begin
+        regb.rdata[i*8+:8] = data[i];
+      end
+    end
+  end
+
+endmodule

--- a/target/rtl/test/testharness.sv.tpl
+++ b/target/rtl/test/testharness.sv.tpl
@@ -101,7 +101,7 @@ module testharness import occamy_pkg::*; (
     .rst_periph_ni,
     .rtc_i,
     .test_mode_i (1'b0),
-    .chip_id_i ('0),
+    .chip_id_i (${chip_id}),
     .boot_mode_i ('0),
     .uart_tx_o (tx),
     .uart_cts_ni ('0),

--- a/target/rtl/test/verilator_lib.cc
+++ b/target/rtl/test/verilator_lib.cc
@@ -1,0 +1,122 @@
+// Copyright 2020 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+#include <printf.h>
+
+#include "Vtestharness.h"
+#include "Vtestharness__Dpi.h"
+#include "sim.hh"
+#include "tb_lib.hh"
+#include "verilated.h"
+#include "verilated_vcd_c.h"
+namespace sim {
+
+// Number of cycles between HTIF checks.
+const int HTIFTimeInterval = 200;
+
+// We want to return timestamp in picosecond accuracy, assuming that one cycle
+// takes 1ns Since 1 cycle takes 2 sim::TIME increments, scale by 500 to get
+// time = cycle * 1000 + <some constant>
+const int TIME_CYCLES_TO_TIMESTAMP = 500;
+void sim_thread_main(void *arg) { ((Sim *)arg)->main(); }
+
+// Sim time.
+vluint64_t TIME = 0;
+
+Sim::Sim(int argc, char **argv) : htif_t(argc, argv), ipc(argc, argv) {
+    // Search arguments for `--vcd` flag and enable waves if requested
+    for (auto i = 1; i < argc; ++i) {
+        if (strcmp(argv[i], "--vcd") == 0) {
+            printf("VCD wave generation enabled\n");
+            vlt_vcd = true;
+        }
+    }
+    Verilated::commandArgs(argc, argv);
+}
+
+void Sim::idle() { target.switch_to(); }
+
+/// Execute the simulation.
+int Sim::run() {
+    host = context_t::current();
+    target.init(sim_thread_main, this);
+    return htif_t::run();
+}
+
+void Sim::main() {
+    // Initialize verilator environment.
+    Verilated::traceEverOn(true);
+    // Allocate the simulation state and VCD trace.
+    auto top = std::make_unique<Vtestharness>();
+    auto vcd = std::make_unique<VerilatedVcdC>();
+
+    bool clk_i = 0, rst_ni = 0;
+
+    // Trace 8 levels of hierarchy.
+    if (vlt_vcd) {
+        top->trace(vcd.get(), 8);
+        vcd->open("sim.vcd");
+        vcd->dump(TIME);
+    }
+    TIME += 2;
+
+    while (!Verilated::gotFinish()) {
+        clk_i = !clk_i;
+        rst_ni = TIME >= 8;
+        top->clk_i = clk_i;
+        top->rst_ni = rst_ni;
+        // Evaluate the DUT.
+        top->eval();
+        if (vlt_vcd) vcd->dump(TIME);
+        // Increase global time.
+        TIME++;
+        // Switch to the HTIF interface in regular intervals.
+        if (TIME % HTIFTimeInterval == 0) {
+            host->switch_to();
+        }
+    }
+
+    // Clean up.
+    if (vlt_vcd) vcd->close();
+}
+}  // namespace sim
+
+// Verilator callback to get the current time.
+double sc_time_stamp() { return sim::TIME * sim::TIME_CYCLES_TO_TIMESTAMP; }
+
+// DPI calls.
+void tb_memory_read(long long addr, int len, const svOpenArrayHandle data) {
+    // std::cout << "[TB] Read " << std::hex << addr << std::dec << " (" << len
+    //           << " bytes)\n";
+    void *data_ptr = svGetArrayPtr(data);
+    assert(data_ptr);
+    sim::MEM.read(addr, len, (uint8_t *)data_ptr);
+}
+
+void tb_memory_write(long long addr, int len, const svOpenArrayHandle data,
+                     const svOpenArrayHandle strb) {
+    // std::cout << "[TB] Write " << std::hex << addr << std::dec << " (" << len
+    //           << " bytes)\n";
+    const void *data_ptr = svGetArrayPtr(data);
+    const void *strb_ptr = svGetArrayPtr(strb);
+    assert(data_ptr);
+    assert(strb_ptr);
+    sim::MEM.write(addr, len, (const uint8_t *)data_ptr,
+                   (const uint8_t *)strb_ptr);
+}
+
+const long long clint_addr = sim::BOOTDATA.clint_base;
+const long num_cores = sim::BOOTDATA.core_count;
+
+void clint_tick(const svOpenArrayHandle msip) {
+    uint8_t *msip_ptr = (uint8_t *)svGetArrayPtr(msip);
+    assert(msip_ptr);
+    uint32_t read_val;
+    for (int i = 0; i < num_cores; i++) {
+        if (i % 32 == 0)
+            sim::MEM.read(clint_addr + i / 32, sizeof(uint32_t),
+                          (uint8_t *)&read_val);
+        msip_ptr[i] = (read_val & (1 << (i % 32))) != 0 ? 1 : 0;
+    }
+}

--- a/target/sim/Makefile
+++ b/target/sim/Makefile
@@ -37,8 +37,7 @@ TXT_TRACES          += $(CVA6_TXT_TRACE)
 PERF_DUMPS          += $(CVA6_PERF_DUMP)
 ANNOTATED_TRACES    += $(CVA6_ANNOTATED_TRACE)
 
-include ../../deps/snitch_cluster/target/common/common.mk
-
+include $(SIM_MKFILE_DIR)/sim.mk
 include $(ROOT)/target/rtl/Makefile
 
 ############
@@ -349,7 +348,7 @@ ${VLT_AR}: ${VLT_SOURCES} ${TB_SRCS}
 verilate: ${VLT_AR}
 
 # Build targets for verilator TB
-$(VLT_BUILDDIR)/tb/%.o: $(TB_DIR)/%.cc $(VLT_AR) ${VLT_BUILDDIR}/lib/libfesvr.a
+$(VLT_BUILDDIR)/tb/%.o: ${MKFILE_DIR}/test/%.cc $(VLT_AR) ${VLT_BUILDDIR}/lib/libfesvr.a
 	mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) $(VLT_CFLAGS) -c $< -o $@
 $(VLT_BUILDDIR)/vlt/%.o: $(VLT_ROOT)/include/%.cpp

--- a/target/sim/sim.mk
+++ b/target/sim/sim.mk
@@ -1,0 +1,289 @@
+
+# The original common.mk file is pasted here
+
+LOGS_DIR ?= logs
+UTIL_DIR ?= $(SNITCH_ROOT)/util
+
+# SEPP packages
+QUESTA_SEPP    ?=
+VCS_SEPP       ?=
+VERILATOR_SEPP ?=
+
+# External executables
+BENDER       ?= bender
+DASM         ?= spike-dasm
+VLT          ?= $(VERILATOR_SEPP) verilator
+VCS          ?= $(VCS_SEPP) vcs
+VERIBLE_FMT  ?= verible-verilog-format
+CLANG_FORMAT ?= clang-format
+VSIM         ?= $(QUESTA_SEPP) vsim
+VOPT         ?= $(QUESTA_SEPP) vopt
+VLOG         ?= $(QUESTA_SEPP) vlog
+VLIB         ?= $(QUESTA_SEPP) vlib
+
+# Internal executables
+GENTRACE_PY      ?= $(UTIL_DIR)/trace/gen_trace.py
+ANNOTATE_PY      ?= $(UTIL_DIR)/trace/annotate.py
+EVENTS_PY        ?= $(UTIL_DIR)/trace/events.py
+PERF_CSV_PY      ?= $(UTIL_DIR)/trace/perf_csv.py
+LAYOUT_EVENTS_PY ?= $(UTIL_DIR)/trace/layout_events.py
+EVENTVIS_PY      ?= $(UTIL_DIR)/trace/eventvis.py
+
+VERILATOR_ROOT ?= $(dir $(shell $(VERILATOR_SEPP) which verilator))..
+VLT_ROOT       ?= ${VERILATOR_ROOT}
+VERILATOR_VERSION ?= $(shell $(VLT) --version | grep -oP 'Verilator \K\d+')
+
+MATCH_END := '/+incdir+/ s/$$/\/*\/*/'
+MATCH_BGN := 's/+incdir+//g'
+SED_SRCS  := sed -e ${MATCH_END} -e ${MATCH_BGN}
+
+VSIM_BENDER   += -t test -t rtl -t simulation -t vsim
+VSIM_SOURCES   = $(shell ${BENDER} script flist ${VSIM_BENDER} | ${SED_SRCS})
+VSIM_BUILDDIR ?= work-vsim
+VOPT_FLAGS     = +acc
+
+# VCS_BUILDDIR should to be the same as the `DEFAULT : ./work-vcs`
+# in target/snitch_cluster/synopsys_sim.setup
+VCS_BENDER   += -t test -t rtl -t simulation -t vcs
+VCS_SOURCES   = $(shell ${BENDER} script flist ${VCS_BENDER} | ${SED_SRCS})
+VCS_BUILDDIR := work-vcs
+
+# For synthesis with DC compiler
+SYN_FLIST ?= syn_flist.tcl
+SYN_BENDER += -t test -t synthesis -t simulation
+ifeq ($(MEM_TYPE), exclude_tcsram)
+	VSIM_BENDER += -t tech_cells_generic_exclude_tc_sram
+	SYN_BENDER  += -t tech_cells_generic_exclude_tc_sram
+endif
+ifeq ($(MEM_TYPE), prep_syn_mem)
+        VSIM_BENDER += -t tech_cells_generic_exclude_tc_sram
+        SYN_BENDER  += -t tech_cells_generic_exclude_tc_sram
+        SYN_BENDER  += -t prep_syn_mem
+endif
+ifeq ($(SIM_TYPE), gate_level_sim)
+        VSIM_BENDER += -t gate_level_sim
+endif
+SYN_SOURCES = $(shell ${BENDER} script synopsys ${SYN_BENDER})
+SYN_BUILDDIR := work-syn
+
+# fesvr is being installed here
+FESVR         ?= ${MKFILE_DIR}work
+FESVR_VERSION ?= 98d2c29e431f3b14feefbda48c5f70c2f451acf2
+
+VLT_BENDER   += -t rtl
+VLT_SOURCES   = $(shell ${BENDER} script flist ${VLT_BENDER} | ${SED_SRCS})
+VLT_BUILDDIR := work-vlt
+VLT_FESVR     = $(VLT_BUILDDIR)/riscv-isa-sim
+ifeq ($(VERILATOR_VERSION), 5)
+	VLT_FLAGS += --timing
+endif
+VLT_FLAGS    += -Wno-BLKANDNBLK
+VLT_FLAGS    += -Wno-LITENDIAN
+VLT_FLAGS    += -Wno-CASEINCOMPLETE
+VLT_FLAGS    += -Wno-CMPCONST
+VLT_FLAGS    += -Wno-WIDTH
+VLT_FLAGS    += -Wno-WIDTHCONCAT
+VLT_FLAGS    += -Wno-UNSIGNED
+VLT_FLAGS    += -Wno-UNOPTFLAT
+VLT_FLAGS    += -Wno-fatal
+VLT_FLAGS    += +define+SYNTHESIS
+VLT_FLAGS    += --unroll-count 1024
+ifeq ($(VERILATOR_VERSION), 5)
+	VLT_CXXSTD_FLAGS += -std=c++20 -pthread -latomic
+else 
+	VLT_CXXSTD_FLAGS += -std=c++17 -pthread
+endif
+VLT_CFLAGS   += ${VLT_CXXSTD_FLAGS} -I ${VLT_BUILDDIR} -I $(VLT_ROOT)/include -I $(VLT_ROOT)/include/vltstd -I $(VLT_FESVR)/include -I ${MKFILE_DIR}/test
+
+ANNOTATE_FLAGS ?= -q --keep-time
+
+# We need a recent LLVM installation (>11) to compile Verilator.
+# We also need to link the binaries with LLVM's libc++.
+# Define CLANG_PATH to be the path of your Clang installation.
+
+ifneq (${CLANG_PATH},)
+    CLANG_CC       := $(CLANG_PATH)/bin/clang
+    CLANG_CXX      := $(CLANG_PATH)/bin/clang++
+    CLANG_CXXFLAGS := -nostdinc++ -isystem $(CLANG_PATH)/include/c++/v1
+    CLANG_LDFLAGS  := -nostdlib++ -fuse-ld=lld -L ${CLANG_PATH}/lib -Wl,-rpath,${CLANG_PATH}/lib -lc++
+else
+    CLANG_CC       ?= clang
+    CLANG_CXX      ?= clang++
+    CLANG_CXXFLAGS := ""
+    CLANG_LDFLAGS  := ""
+endif
+
+# If requested, build verilator with LLVM and add llvm c/ld flags
+ifeq ($(VLT_USE_LLVM),ON)
+    CC         = $(CLANG_CC)
+    CXX        = $(CLANG_CXX)
+    CFLAGS     = $(CLANG_CXXFLAGS)
+    CXXFLAGS   = $(CLANG_CXXFLAGS)
+    LDFLAGS    = $(CLANG_LDFLAGS)
+    VLT_FLAGS += --compiler clang
+    VLT_FLAGS += -CFLAGS "${CLANG_CXXFLAGS}"
+    VLT_FLAGS += -LDFLAGS "${CLANG_LDFLAGS}"
+endif
+
+VLOGAN_FLAGS := -assert svaext
+VLOGAN_FLAGS += -assert disable_cover
+VLOGAN_FLAGS += -full64
+VLOGAN_FLAGS += -kdb
+VHDLAN_FLAGS := -full64
+VHDLAN_FLAGS += -kdb
+
+# default on target `all`
+all:
+
+#################
+# Prerequisites #
+#################
+# Eventually it could be an option to package this statically using musl libc.
+work/${FESVR_VERSION}_unzip:
+	mkdir -p $(dir $@)
+	wget -O $(dir $@)/${FESVR_VERSION} https://github.com/riscv/riscv-isa-sim/tarball/${FESVR_VERSION}
+	tar xfm $(dir $@)${FESVR_VERSION} --strip-components=1 -C $(dir $@)
+	touch $@
+
+work/lib/libfesvr.a: work/${FESVR_VERSION}_unzip
+	cd $(dir $<)/ && ./configure --prefix `pwd`
+	make -C $(dir $<) install-config-hdrs install-hdrs libfesvr.a
+	mkdir -p $(dir $@)
+	cp $(dir $<)libfesvr.a $@
+
+# Build fesvr seperately for verilator since this might use different compilers
+# and libraries than modelsim/vcs and
+$(VLT_FESVR)/${FESVR_VERSION}_unzip:
+	mkdir -p $(dir $@)
+	wget -O $(dir $@)/${FESVR_VERSION} https://github.com/riscv/riscv-isa-sim/tarball/${FESVR_VERSION}
+	tar xfm $(dir $@)${FESVR_VERSION} --strip-components=1 -C $(dir $@)
+	touch $@
+
+$(VLT_BUILDDIR)/lib/libfesvr.a: $(VLT_FESVR)/${FESVR_VERSION}_unzip
+	cd $(dir $<)/ && ./configure --prefix `pwd` \
+        CC=${CC} CXX=${CXX} CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}"
+	$(MAKE) -C $(dir $<) install-config-hdrs install-hdrs libfesvr.a
+	mkdir -p $(dir $@)
+	cp $(dir $<)libfesvr.a $@
+
+#############
+# Verilator #
+#############
+# Takes the top module name as an argument.
+define VERILATE
+	mkdir -p $(dir $@)
+	$(BENDER) script verilator ${VLT_BENDER} > $(dir $@)files
+	+$(VLT) \
+		--Mdir $(dir $@) -f $(dir $@)files $(VLT_FLAGS) \
+		-j $(shell nproc) --cc --build --top-module $(1)
+	touch $@
+endef
+
+############
+# Modelsim #
+############
+
+$(VSIM_BUILDDIR):
+	mkdir -p $@
+
+# Expects vlog/vcom script in $< (e.g. as output by bender)
+# Expects the top module name in $1
+# Produces a binary used to run the simulation at the path specified by $@
+define QUESTASIM
+	${VSIM} -c -do "source $<; quit" | tee $(dir $<)vlog.log
+	@! grep -P "Errors: [1-9]*," $(dir $<)vlog.log
+	$(VOPT) $(VOPT_FLAGS) -work $(VSIM_BUILDDIR) $1 -o $(1)_opt | tee $(dir $<)vopt.log
+	@! grep -P "Errors: [1-9]*," $(dir $<)vopt.log
+	@mkdir -p $(dir $@)
+	@echo "#!/bin/bash" > $@
+	@echo 'binary=$$(realpath $$1)' >> $@
+	@echo 'mkdir -p $(LOGS_DIR)' >> $@
+	@echo 'echo $$binary > $(LOGS_DIR)/.rtlbinary' >> $@
+	@echo '${VSIM} +permissive ${VSIM_FLAGS} $$3 -work ${MKFILE_DIR}/${VSIM_BUILDDIR} -c \
+				-ldflags "-Wl,-rpath,${FESVR}/lib -L${FESVR}/lib -lfesvr -lutil" \
+				$(1)_opt +permissive-off ++$$binary ++$$2' >> $@
+	@chmod +x $@
+	@echo "#!/bin/bash" > $@.gui
+	@echo 'binary=$$(realpath $$1)' >> $@.gui
+	@echo 'mkdir -p $(LOGS_DIR)' >> $@.gui
+	@echo 'echo $$binary > $(LOGS_DIR)/.rtlbinary' >> $@.gui
+	@echo '${VSIM} +permissive ${VSIM_FLAGS} -work ${MKFILE_DIR}/${VSIM_BUILDDIR} \
+				-ldflags "-Wl,-rpath,${FESVR}/lib -L${FESVR}/lib -lfesvr -lutil" \
+				$(1)_opt +permissive-off ++$$binary ++$$2' >> $@.gui
+	@chmod +x $@.gui
+endef
+
+#######
+# VCS #
+#######
+$(VCS_BUILDDIR)/compile.sh:
+	mkdir -p $(VCS_BUILDDIR)
+	${BENDER} script vcs ${VCS_BENDER} --vlog-arg="${VLOGAN_FLAGS}" --vcom-arg="${VHDLAN_FLAGS}" > $@
+	chmod +x $@
+	$(VCS_SEPP) $@ > $(VCS_BUILDDIR)/compile.log
+
+########
+# Util #
+########
+
+# Common rule to generate C header with REGGEN
+# $1: target name, $2: prerequisite (hjson description file)
+define reggen_generate_header
+	@echo "[REGGEN] Generating $1"
+	@$(REGGEN) -D -o $1 $2
+	@$(CLANG_FORMAT) -i $1
+endef
+
+# Arg 1: binary
+# Arg 2: max size in bytes
+define BINARY_SIZE_CHECK
+  echo "Binary size: $$(stat -c %s $(1))B"
+  @[ "$$(stat -c %s $(1))" -lt "$(2)" ] || (echo "Binary exceeds specified size of $(2)B"; exit 1)
+endef
+
+##########
+# Traces #
+##########
+
+DASM_TRACES      = $(shell (ls $(LOGS_DIR)/trace_hart_*.dasm 2>/dev/null))
+TXT_TRACES       = $(shell (echo $(DASM_TRACES) | sed 's/\.dasm/\.txt/g'))
+PERF_TRACES      = $(shell (echo $(DASM_TRACES) | sed 's/trace_hart/hart/g' | sed 's/.dasm/_perf.json/g'))
+ANNOTATED_TRACES = $(shell (echo $(DASM_TRACES) | sed 's/\.dasm/\.s/g'))
+DIFF_TRACES      = $(shell (echo $(DASM_TRACES) | sed 's/\.dasm/\.diff/g'))
+
+GENTRACE_OUTPUTS = $(TXT_TRACES) $(PERF_TRACES)
+ANNOTATE_OUTPUTS = $(ANNOTATED_TRACES)
+PERF_CSV         = $(LOGS_DIR)/perf.csv
+EVENT_CSV        = $(LOGS_DIR)/event.csv
+TRACE_CSV        = $(LOGS_DIR)/trace.csv
+TRACE_JSON       = $(LOGS_DIR)/trace.json
+
+.PHONY: traces annotate perf-csv event-csv layout
+traces: $(GENTRACE_OUTPUTS)
+annotate: $(ANNOTATE_OUTPUTS)
+perf-csv: $(PERF_CSV)
+event-csv: $(EVENT_CSV)
+layout: $(TRACE_CSV) $(TRACE_JSON)
+
+$(LOGS_DIR)/trace_hart_%.txt $(LOGS_DIR)/hart_%_perf.json: $(LOGS_DIR)/trace_hart_%.dasm $(GENTRACE_PY)
+	$(DASM) < $< | $(PYTHON) $(GENTRACE_PY) --permissive -d $(LOGS_DIR)/hart_$*_perf.json > $(LOGS_DIR)/trace_hart_$*.txt
+
+# Generate source-code interleaved traces for all harts. Reads the binary from
+# the logs/.rtlbinary file that is written at start of simulation in the vsim script
+BINARY ?= $(shell cat $(LOGS_DIR)/.rtlbinary)
+$(LOGS_DIR)/trace_hart_%.s: $(LOGS_DIR)/trace_hart_%.txt ${ANNOTATE_PY}
+	$(PYTHON) ${ANNOTATE_PY} ${ANNOTATE_FLAGS} -o $@ $(BINARY) $<
+$(LOGS_DIR)/trace_hart_%.diff: $(LOGS_DIR)/trace_hart_%.txt ${ANNOTATE_PY}
+	$(PYTHON) ${ANNOTATE_PY} ${ANNOTATE_FLAGS} -o $@ $(BINARY) $< -d
+
+$(PERF_CSV): $(PERF_TRACES) $(PERF_CSV_PY)
+	$(PYTHON) $(PERF_CSV_PY) -o $@ -i $(PERF_TRACES)
+
+$(EVENT_CSV): $(PERF_TRACES) $(PERF_CSV_PY)
+	$(PYTHON) $(PERF_CSV_PY) -o $@ -i $(PERF_TRACES) --filter tstart tend
+
+$(TRACE_CSV): $(EVENT_CSV) $(LAYOUT_FILE) $(LAYOUT_EVENTS_PY)
+	$(PYTHON) $(LAYOUT_EVENTS_PY) $(LAYOUT_EVENTS_FLAGS) $(EVENT_CSV) $(LAYOUT_FILE) -o $@
+
+$(TRACE_JSON): $(TRACE_CSV) $(EVENTVIS_PY)
+	$(PYTHON) $(EVENTVIS_PY) -o $@ $(TRACE_CSV)

--- a/util/occamygen/occamy.py
+++ b/util/occamygen/occamy.py
@@ -619,25 +619,30 @@ def get_bootdata_kwargs(occamy_cfg, cluster_generators, name):
 
     bootdata_kwargs = {
         "name": name,
-        "boot_addr": hex(occamy_cfg["peripherals"]["rom"]["address"]),
+        "boot_addr": occamy_cfg["peripherals"]["rom"]["address"],
         "core_count": nr_cores_quadrant,
         "hart_id_base": 1,
-        "tcdm_start": hex(cluster_cfg["cluster_base_addr"]),
-        "tcdm_size": hex(cluster_cfg["tcdm"]["size"]*1024),
-        "tcdm_offset": hex(cluster_cfg["cluster_base_offset"]),
-        "global_mem_start": hex(occamy_cfg["spm_wide"]["address"]),
-        "global_mem_end": hex(occamy_cfg["spm_wide"]["address"] + occamy_cfg["spm_wide"]["length"]),
+        "addr_width": occamy_cfg["addr_width"],
+        "chip_id_width": occamy_cfg["hemaia_multichip"]["chip_id_width"],
+        "single_chip": occamy_cfg["hemaia_multichip"]["single_chip"],
+        "single_chip_id": occamy_cfg["hemaia_multichip"]["single_chip_id"],
+        "tcdm_start": cluster_cfg["cluster_base_addr"],
+        "tcdm_size": cluster_cfg["tcdm"]["size"]*1024,
+        "tcdm_offset": cluster_cfg["cluster_base_offset"],
+        "global_mem_start": occamy_cfg["spm_wide"]["address"],
+        "global_mem_end": occamy_cfg["spm_wide"]["address"] + occamy_cfg["spm_wide"]["length"],
         "cluster_count": len(occamy_cfg["clusters"]),
         "s1_quadrant_count": occamy_cfg["nr_s1_quadrant"],
-        "clint_base": hex(occamy_cfg["peripherals"]["clint"]["address"])
+        "clint_base": occamy_cfg["peripherals"]["clint"]["address"]
     }
     return bootdata_kwargs
 
 
-def get_testharness_kwargs(soc_wide_xbar, soc_axi_lite_narrow_periph_xbar, solder, name):
+def get_testharness_kwargs(soc_wide_xbar, soc_axi_lite_narrow_periph_xbar, chip_id, solder, name):
     testharness_kwargs = {
         "name": name,
         "solder": solder,
+        "chip_id": chip_id, 
         "soc_wide_xbar": soc_wide_xbar,
         "soc_axi_lite_narrow_periph_xbar": soc_axi_lite_narrow_periph_xbar
     }

--- a/util/occamygen/occamygen.py
+++ b/util/occamygen/occamygen.py
@@ -601,7 +601,7 @@ def main():
     ###############
     if args.testharness_sv:
         testharness_kwargs = occamy.get_testharness_kwargs(
-            soc_wide_xbar, soc_axi_lite_narrow_periph_xbar, solder, name)
+            soc_wide_xbar, soc_axi_lite_narrow_periph_xbar, occamy_cfg["hemaia_multichip"]["single_chip_id"], solder, name)
         write_template(args.testharness_sv, outdir, **testharness_kwargs)
 
     ############


### PR DESCRIPTION
This PR did the following changes for chiplet modification: 
- Automatic generation of testharness and bootdata.cc for chips do not reside in position zero
- Copy all src files under snitch/target/common into HeMAiA, and prepare for the later more flexible multichip testbench