### PR TITLE
Add error checking for failed snax-gen make files

### DIFF
--- a/target/rtl/cfg/cluster_cfg/snax_KUL_cluster.hjson
+++ b/target/rtl/cfg/cluster_cfg/snax_KUL_cluster.hjson
@@ -124,6 +124,10 @@
             snax_wide_tcdm_ports: 48,
             snax_num_rw_csr: 10,
             snax_num_ro_csr: 2,
+            snax_gemmx_mesh_row: 8,
+            snax_gemmx_tile_size: 8,
+            snax_gemmx_mesh_col: 8,
+            with_pipeline: false,
             snax_streamer_cfg: {$ref: "#/snax_streamer_gemmX_streamer_template" }
         },
         snax_use_custom_ports: false,

--- a/target/rtl/cfg/cluster_cfg/snax_KUL_xdma_cluster.hjson
+++ b/target/rtl/cfg/cluster_cfg/snax_KUL_xdma_cluster.hjson
@@ -121,6 +121,10 @@
             bender_target: ["snax_gemmX"],
             snax_narrow_tcdm_ports: 8,
             snax_wide_tcdm_ports: 48,
+            snax_gemmx_mesh_row: 8,
+            snax_gemmx_tile_size: 8,
+            snax_gemmx_mesh_col: 8,
+            with_pipeline: false,
             snax_num_rw_csr: 10,
             snax_num_ro_csr: 2,
             snax_streamer_cfg: {$ref: "#/snax_streamer_gemmX_streamer_template" }

--- a/util/occamygen/occamy.py
+++ b/util/occamygen/occamy.py
@@ -81,7 +81,11 @@ def get_cluster_cfg_list(occamy_cfg, cluster_cfg_dir):
 
 def generate_snitch(cluster_cfg_dir, snitch_path):
     for cfg in cluster_cfg_dir:
-        subprocess.call(f"make -C {snitch_path}/target/snitch_cluster CFG_OVERRIDE={cfg} rtl-gen", shell=True)
+        try:
+            subprocess.check_call(f"make -C {snitch_path}/target/snitch_cluster CFG_OVERRIDE={cfg} rtl-gen", shell=True)
+        except subprocess.CalledProcessError as e:
+            print("Error! SNAX gen fails. Check the log.")
+            raise
 
 def generate_wrappers(cluster_generators,out_dir):
     for cluster_generator in cluster_generators:

--- a/util/occamygen/occamy.py
+++ b/util/occamygen/occamy.py
@@ -82,7 +82,7 @@ def get_cluster_cfg_list(occamy_cfg, cluster_cfg_dir):
 def generate_snitch(cluster_cfg_dir, snitch_path):
     for cfg in cluster_cfg_dir:
         try:
-            subprocess.check_call(f"make -C {snitch_path}/target/snitch_cluster CFG_OVERRIDE={cfg} rtl-gen", shell=True)
+            subprocess.check_call(f"make -C {snitch_path}/target/snitch_cluster CFG_OVERRIDE={cfg} DISABLE_HEADER_GEN=true rtl-gen", shell=True)
         except subprocess.CalledProcessError as e:
             print("Error! SNAX gen fails. Check the log.")
             raise


### PR DESCRIPTION
This PR adds additional error checking if snax gen fails it terminates the `occamygen` as early as possible.

The problem arises because it calls a subprocess `make -C` but even when the make fails, it does not propagate an error toward the occamygen.

This PR adds a fix to it.