### PR TITLE
To enable the clk gating at cluster level

### DIFF
--- a/hw/occamy/occamy_quadrant_s1.sv.tpl
+++ b/hw/occamy/occamy_quadrant_s1.sv.tpl
@@ -66,7 +66,9 @@ module ${name}_quadrant_s1
   `AXI_TLB_TYPEDEF_ALL(tlb, logic [AddrWidth-12-1:0], logic [AddrWidth-12-1:0])
 
   // Signals from Controller
-  logic clk_quadrant, rst_quadrant_n;
+  logic clk_quadrant_uncore, rst_quadrant_n;
+  logic [${nr_clusters-1}:0] clk_quadrant_cluster;
+
   logic [3:0] isolate, isolated;
   logic ro_enable, ro_flush_valid, ro_flush_ready;
   logic [${ro_cache_regions-1}:0][${soc_wide_xbar.in_quadrant_0.aw-1}:0] ro_start_addr, ro_end_addr;
@@ -93,7 +95,7 @@ module ${name}_quadrant_s1
       .declare(context)
     narrow_cluster_in_ctrl \
       .cut(context, cuts_narrx_with_ctrl) \
-      .isolate(context, "isolate[0]", "narrow_cluster_in_isolate", isolated="isolated[0]", terminated=True, to_clk="clk_quadrant", to_rst="rst_quadrant_n", num_pending=narrow_trans) \
+      .isolate(context, "isolate[0]", "narrow_cluster_in_isolate", isolated="isolated[0]", terminated=True, to_clk="clk_quadrant_uncore", to_rst="rst_quadrant_n", num_pending=narrow_trans) \
       .change_iw(context, narrow_xbar_quadrant_s1.in_top.iw, "narrow_cluster_in_iwc", to=narrow_xbar_quadrant_s1.in_top)
   %>
 
@@ -172,7 +174,7 @@ module ${name}_quadrant_s1
       .copy(name="wide_cluster_in_iwc") \
       .declare(context) \
       .cut(context, cuts_wideiwc_with_wideout) \
-      .isolate(context, "isolate[2]", "wide_cluster_in_isolate", isolated="isolated[2]", terminated=True, atop_support=False, to_clk="clk_quadrant", to_rst="rst_quadrant_n", num_pending=wide_trans) \
+      .isolate(context, "isolate[2]", "wide_cluster_in_isolate", isolated="isolated[2]", terminated=True, atop_support=False, to_clk="clk_quadrant_uncore", to_rst="rst_quadrant_n", num_pending=wide_trans) \
       .cut(context, cuts_wideisolate_with_wideiwc_in) \
       .change_iw(context, wide_xbar_quadrant_s1.in_top.iw, "wide_cluster_in_iwc", to=wide_xbar_quadrant_s1.in_top)
   %>
@@ -190,7 +192,8 @@ module ${name}_quadrant_s1
     .rst_ni,
     .test_mode_i,
     .chip_id_i,
-    .clk_quadrant_o (clk_quadrant),
+    .clk_quadrant_uncore_o (clk_quadrant_uncore),
+    .clk_quadrant_cluster_o (clk_quadrant_cluster),
     .rst_quadrant_no (rst_quadrant_n),
     .isolate_o (isolate),
     .isolated_i (isolated),
@@ -235,7 +238,7 @@ module ${name}_quadrant_s1
   assign hart_base_id_${i} = HartIdOffset + NrCoresClusterOffset[${i}];
 
   ${cluster_name}_wrapper i_${name}_cluster_${i} (
-    .clk_i (clk_quadrant),
+    .clk_i (clk_quadrant_cluster[${i}]),
     .rst_ni (rst_quadrant_n),
     .meip_i (meip_i[NrCoresClusterOffset[${i}]+:NrCoresCluster[${i}]]),
     .mtip_i (mtip_i[NrCoresClusterOffset[${i}]+:NrCoresCluster[${i}]]),

--- a/hw/occamy/occamy_quadrant_s1_ctrl.sv.tpl
+++ b/hw/occamy/occamy_quadrant_s1_ctrl.sv.tpl
@@ -169,7 +169,7 @@ module ${name}_quadrant_s1_ctrl
 
   tc_clk_gating i_tc_clk_gating_quadrant_cluster_uncore (
     .clk_i,
-    .en_i (reg2hw.clk_ena.en_quad_uncore.q),
+    .en_i (reg2hw.clk_ena.ena_quad_uncore.q),
     .test_en_i (test_mode_i),
     .clk_o (clk_quadrant_uncore_o)
   );

--- a/hw/occamy/occamy_quadrant_s1_ctrl.sv.tpl
+++ b/hw/occamy/occamy_quadrant_s1_ctrl.sv.tpl
@@ -22,7 +22,8 @@ module ${name}_quadrant_s1_ctrl
   input  chip_id_t chip_id_i,
 
   // Quadrant clock and reset
-  output logic clk_quadrant_o,
+  output logic [${num_clusters-1}:0] clk_quadrant_cluster_o,
+  output logic clk_quadrant_uncore_o,
   output logic rst_quadrant_no,
 
   // Quadrant control signals
@@ -157,12 +158,22 @@ module ${name}_quadrant_s1_ctrl
   % endif
 
   // Quadrant clock gate controlled by register
-  tc_clk_gating i_tc_clk_gating_quadrant (
+  % for cluster_idx in range(num_clusters):
+  tc_clk_gating i_tc_clk_gating_quadrant_cluster_${cluster_idx} (
     .clk_i,
-    .en_i (reg2hw.clk_ena.q),
+    .en_i (reg2hw.clk_ena.ena_cluster_${cluster_idx}.q),
     .test_en_i (test_mode_i),
-    .clk_o (clk_quadrant_o)
+    .clk_o (clk_quadrant_cluster_o[${cluster_idx}])
   );
+  % endfor
+
+  tc_clk_gating i_tc_clk_gating_quadrant_cluster_uncore (
+    .clk_i,
+    .en_i (reg2hw.clk_ena.en_quad_uncore.q),
+    .test_en_i (test_mode_i),
+    .clk_o (clk_quadrant_uncore_o)
+  );
+  
 
   // Reset directly from register (i.e. (de)assertion inherently synchronized)
   // Multiplex with glitchless multiplexor, top reset for testing purposes

--- a/hw/occamy/quadrant_s1_ctrl/occamy_quadrant_s1_reg.hjson.tpl
+++ b/hw/occamy/quadrant_s1_ctrl/occamy_quadrant_s1_reg.hjson.tpl
@@ -17,7 +17,10 @@
       hwaccess: "hro",
       // Clock disabled (i.e. gated) by default
       fields: [
-        {bits: "0:0", name: "clk_ena", resval: 0, desc: "Clock gate enable"}
+% for cluster_idx in range(num_clusters):
+        {bits: "${cluster_idx}:${cluster_idx}", name: "ena_cluster_${cluster_idx}", resval: 0, desc: "Clock gate enable for cluster ${cluster_idx}"}
+% endfor
+        {bits: "${num_clusters}:${num_clusters}", name: "ena_quad_uncore",  resval: 0, desc: "Clock gate enable for cluster un-core"},
       ],
     },
     { name: "RESET_N",

--- a/hw/occamy/quadrant_s1_ctrl/occamy_quadrant_s1_reg.hjson.tpl
+++ b/hw/occamy/quadrant_s1_ctrl/occamy_quadrant_s1_reg.hjson.tpl
@@ -18,9 +18,9 @@
       // Clock disabled (i.e. gated) by default
       fields: [
 % for cluster_idx in range(num_clusters):
-        {bits: "${cluster_idx}:${cluster_idx}", name: "ena_cluster_${cluster_idx}", resval: 0, desc: "Clock gate enable for cluster ${cluster_idx}"}
+        {bits: "${cluster_idx}:${cluster_idx}", name: "ena_cluster_${cluster_idx}", resval: 0, desc: "Clock gate enable for cluster ${cluster_idx}"},
 % endfor
-        {bits: "${num_clusters}:${num_clusters}", name: "ena_quad_uncore",  resval: 0, desc: "Clock gate enable for cluster un-core"},
+        {bits: "${num_clusters}:${num_clusters}", name: "ena_quad_uncore",  resval: 0, desc: "Clock gate enable for cluster un-core"}
       ],
     },
     { name: "RESET_N",

--- a/target/sim/sw/host/apps/offload/src/offload.c
+++ b/target/sim/sw/host/apps/offload/src/offload.c
@@ -8,7 +8,12 @@ int main() {
     // Reset and ungate all quadrants, deisolate
     init_uart(32, 1);
     print_uart("[Occamy] The Offload main function \r\n");
-    reset_and_ungate_quadrants();
+    reset_and_ungate_quadrants_all();
+    // To enable the cluster gating
+    // uncore c3 c2 c1 c0
+    // 1      0  0  1  1
+    // 0x13
+    // reset_and_ungate_quadrants(0x13);
     deisolate_all();
 
     // Enable interrupts to receive notice of job termination

--- a/target/sim/sw/host/runtime/host.c
+++ b/target/sim/sw/host/runtime/host.c
@@ -289,25 +289,34 @@ static inline volatile uint32_t* get_shared_lock() {
 // Reset and clock gating
 //===============================================================
 
-static inline void set_clk_ena_quad(uint32_t quad_idx, uint32_t value) {
-    *quad_cfg_clk_ena_ptr(quad_idx) = value & 0x1;
+static inline void set_clk_ena_quad(uint32_t quad_idx, uint32_t value, uint32_t clk_enable_mask) {
+    *quad_cfg_clk_ena_ptr(quad_idx) = value & clk_enable_mask;
 }
+
+// static inline void set_clk_ena_quad(uint32_t quad_idx, uint32_t value) {
+//     *quad_cfg_clk_ena_ptr(quad_idx) = value & 0x1;
+// }
 
 static inline void set_reset_n_quad(uint32_t quad_idx, uint32_t value) {
     *quad_cfg_reset_n_ptr(quad_idx) = value & 0x1;
 }
 
-static inline void reset_and_ungate_quad(uint32_t quadrant_idx) {
+static inline void reset_and_ungate_quad(uint32_t quadrant_idx, uint32_t cluster_enable_value) {
+    // The N_CLUSTER + 1 is for the uncore
+    uint32_t clk_enable_mask = (1 << (N_CLUSTERS + 1) ) - 1;
     set_reset_n_quad(quadrant_idx, 0);
-    set_clk_ena_quad(quadrant_idx, 0);
+    set_clk_ena_quad(quadrant_idx, 0, clk_enable_mask);
     set_reset_n_quad(quadrant_idx, 1);
-    set_clk_ena_quad(quadrant_idx, 1);
+    set_clk_ena_quad(quadrant_idx, cluster_enable_value, clk_enable_mask);
 }
 
-static inline void reset_and_ungate_quadrants() {
-    for (int i = 0; i < N_QUADS; i++) reset_and_ungate_quad(i);
+static inline void reset_and_ungate_quadrants(uint32_t cluster_enable_value) {
+    for (int i = 0; i < N_QUADS; i++) reset_and_ungate_quad(i, cluster_enable_value);
 }
 
+static inline void reset_and_ungate_quadrants_all() {
+    for (int i = 0; i < N_QUADS; i++) reset_and_ungate_quad(i, 0xFFFF);
+}
 //===============================================================
 // Interrupts
 //===============================================================

--- a/util/occamygen/occamy.py
+++ b/util/occamygen/occamy.py
@@ -438,6 +438,7 @@ def get_soc_kwargs(occamy_cfg, cluster_generators, soc_narrow_xbar, soc_wide_xba
 
 
 def get_quadrant_ctrl_kwargs(occamy_cfg, soc_wide_xbar, soc_narrow_xbar, quadrant_s1_ctrl_xbars, quadrant_s1_ctrl_mux, name):
+    num_clusters = len(occamy_cfg["clusters"])
     ro_cache_cfg = occamy_cfg["s1_quadrant"].get("ro_cache_cfg", {})
     ro_cache_regions = ro_cache_cfg.get("address_regions", 1)
     narrow_tlb_cfg = occamy_cfg["s1_quadrant"].get("narrow_tlb_cfg", {})
@@ -448,6 +449,7 @@ def get_quadrant_ctrl_kwargs(occamy_cfg, soc_wide_xbar, soc_narrow_xbar, quadran
     quadrant_ctrl_kwargs = {
         "name": name,
         "occamy_cfg": occamy_cfg,
+        "num_clusters": num_clusters,
         "ro_cache_cfg": ro_cache_cfg,
         "ro_cache_regions": ro_cache_regions,
         "narrow_tlb_cfg": narrow_tlb_cfg,

--- a/util/occamygen/occamygen.py
+++ b/util/occamygen/occamygen.py
@@ -434,7 +434,7 @@ def main():
         512,
         occamy_cfg["s1_quadrant"]["wide_xbar_slv_id_width"],
         name="wide_xbar_quadrant_s1",
-        clk="clk_quadrant",
+        clk="clk_quadrant_uncore",
         rst="rst_quadrant_n",
         max_slv_trans=occamy_cfg["s1_quadrant"]["wide_xbar"]["max_slv_trans"],
         max_mst_trans=occamy_cfg["s1_quadrant"]["wide_xbar"]["max_mst_trans"],
@@ -450,7 +450,7 @@ def main():
         occamy_cfg["s1_quadrant"]["narrow_xbar_slv_id_width"],
         occamy_cfg["s1_quadrant"]["narrow_xbar_user_width"],
         name="narrow_xbar_quadrant_s1",
-        clk="clk_quadrant",
+        clk="clk_quadrant_uncore",
         rst="rst_quadrant_n",
         max_slv_trans=occamy_cfg["s1_quadrant"]["narrow_xbar"]
         ["max_slv_trans"],


### PR DESCRIPTION
This PR adds support for clk gating at the cluster level.

Previously the clk gating happened at quad-level. The following changes will enable the clk gating at the cluster level.

1. The quad_s1_ctrl_reg
The key signal controls the quad clk is the `clk_quadrant` in the `occamy_quadrant_s1_ctrl`.
By changing the `HeMAiA/hw/occamy/quadrant_s1_ctrl/occamy_quadrant_s1_reg.hjson.tpl`, we can add more control bits for the CLK_ENA registers.
The corresponding change is 
```
    { name: "CLK_ENA",
      desc: "Quadrant-internal clock gate enable",
      swaccess: "rw",
      hwaccess: "hro",
      // Clock disabled (i.e. gated) by default
      fields: [
% for cluster_idx in range(num_clusters):
        {bits: "${cluster_idx}:${cluster_idx}", name: "ena_cluster_${cluster_idx}", resval: 0, desc: "Clock gate enable for cluster ${cluster_idx}"}
% endfor
        {bits: "${num_clusters}:${num_clusters}", name: "ena_quad_uncore",  resval: 0, desc: "Clock gate enable for cluster un-core"},
      ],
    },
```

This .hjson.tpl will generate the files under target/rtl/src/quadrant_s1_ctrl. The new occamy_quadrant_s1_reg.hjson is 
```
    { name: "CLK_ENA",
      desc: "Quadrant-internal clock gate enable",
      swaccess: "rw",
      hwaccess: "hro",
      // Clock disabled (i.e. gated) by default
      fields: [
        {bits: "0:0", name: "ena_cluster_0", resval: 0, desc: "Clock gate enable for cluster 0"},
        {bits: "1:1", name: "ena_cluster_1", resval: 0, desc: "Clock gate enable for cluster 1"},
        {bits: "2:2", name: "ena_cluster_2", resval: 0, desc: "Clock gate enable for cluster 2"},
        {bits: "3:3", name: "ena_cluster_3", resval: 0, desc: "Clock gate enable for cluster 3"},
        {bits: "4:4", name: "ena_quad_uncore",  resval: 0, desc: "Clock gate enable for cluster un-core"}
      ],
    },
```
We add the control bits for each cluster and also the quad uncores (axi, ro_cache, etc).
2. The quad_s1_ctrl
After we add more bits for the CLK_ENA registers, we also need to change the .tpl of the quad_s1_ctrl.
Previously there was only one bit for the quad
```
  tc_clk_gating i_tc_clk_gating_quadrant (
    .clk_i,
    .en_i (reg2hw.clk_ena.q),
    .test_en_i (test_mode_i),
    .clk_o (clk_quadrant_o)
  );
```
Now we add more control bits according to our changes in the registers
```
 // Quadrant clock gate controlled by register
  % for cluster_idx in range(num_clusters):
  tc_clk_gating i_tc_clk_gating_quadrant_cluster_${cluster_idx} (
    .clk_i,
    .en_i (reg2hw.clk_ena.ena_cluster_${cluster_idx}.q),
    .test_en_i (test_mode_i),
    .clk_o (clk_quadrant_cluster_o[${cluster_idx}])
  );
  % endfor

  tc_clk_gating i_tc_clk_gating_quadrant_cluster_uncore (
    .clk_i,
    .en_i (reg2hw.clk_ena.ena_quad_uncore.q),
    .test_en_i (test_mode_i),
    .clk_o (clk_quadrant_uncore_o)
  );
```
3. quad_s1
After we modify the quad_ctrl, the corresponding clks for each component in the quad should also be changed.
4. Change the host.c SW
Since the clk gating is controlled by writing a register in quad_ctrl, we also need to change the SW to make it works.
The key changes are the 
```
static inline void set_clk_ena_quad(uint32_t quad_idx, uint32_t value, uint32_t clk_enable_mask) {
    *quad_cfg_clk_ena_ptr(quad_idx) = value & clk_enable_mask;
}
```

```
static inline void reset_and_ungate_quad(uint32_t quadrant_idx, uint32_t cluster_enable_value) {
    // The N_CLUSTER + 1 is for the uncore
    uint32_t clk_enable_mask = (1 << (N_CLUSTERS + 1) ) - 1;
    set_reset_n_quad(quadrant_idx, 0);
    set_clk_ena_quad(quadrant_idx, 0, clk_enable_mask);
    set_reset_n_quad(quadrant_idx, 1);
    set_clk_ena_quad(quadrant_idx, cluster_enable_value, clk_enable_mask);
}
```

```
static inline void reset_and_ungate_quadrants(uint32_t cluster_enable_value) {
    for (int i = 0; i < N_QUADS; i++) reset_and_ungate_quad(i, cluster_enable_value);
}
```
The above functions enable use to set the value of the CLK_ENA registers.

Usage of such a new feature is just calling the `reset_and_ungate_quadrants(cluster_enable_value)` during the offload.c
```
    reset_and_ungate_quadrants_all();
    // To enable the cluster gating
    // uncore c3 c2 c1 c0
    // 1      0  0  1  1
    // 0x13
    // reset_and_ungate_quadrants(0x13);
```
If we want to turn on all the components in the quadrant, we use the `reset_and_ungate_quadrants_all()`. If we turn on the specific components, we can do it by setting the bitfield of the cluster_enable_value.
