### PR TITLE
Update the bender target

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -46,7 +46,7 @@ sources:
     files:
       - target/tapeout/tc_sram/tc_sram_print/tc_sram.sv
       - target/tapeout/tc_sram/tc_sram_print/tc_sram_impl.sv
-  - target: all(tech_cells_generic_exclude_tc_sram, any(prep_syn_test,syn))
+  - target: all(tech_cells_generic_exclude_tc_sram, any(prep_syn_test,synthesis))
     files:
       - /users/micas/shares/project_snax/tapeout_modules/hemaia/tc_sram_impl.sv
 
@@ -112,9 +112,12 @@ sources:
     files:
       - target/rtl/test/uartdpi/uartdpi.sv
       - target/rtl/test/testharness.sv
-
-  - target: any(tapeout, hemaia, prep_syn, syn)
+  
+  - target: hemaia
     files:
       - target/rtl/bootrom/bootrom.sv
       - target/rtl/src/occamy_chip.sv
+
+  - target: tsmc_pad
+    files:
       - /users/micas/shares/project_snax/tapeout_modules/hemaia/hemaia_chip_top.sv

--- a/target/tapeout/Makefile
+++ b/target/tapeout/Makefile
@@ -73,7 +73,8 @@ SYN_BENDER = -t rtl
 SYN_BENDER += -t synthesis
 SYN_BENDER += -t occamy
 SYN_BENDER += -t tech_cells_generic_exclude_tc_sram
-SYN_BENDER += -t syn
+SYN_BENDER += -t hemaia
+SYN_BENDER += -t tsmc_pad
 SYN_BENDER += $(shell cat ../rtl/src/bender_targets.tmp)
 SYN_ROOT = /users/micas/shares/project_snax/projects/hemaia/HeMAiA
 


### PR DESCRIPTION
This PR updates the bender target.
1. Split the "any(tapeout, hemaia, prep_syn, syn)" to two targets "hemaia" and "tsmc_pad"
The "hemaia" target is for the FPGA and ASIC and contains the `occamy_chip.sv` and `bootrom.sv`
The "tsmc_pad" is only used for the tsmc special pad requirement
3. the "syn" target is merged with "synthesis"