### PR TITLE
Update the boot addr control

### DIFF
--- a/hw/occamy/occamy_top.sv.tpl
+++ b/hw/occamy/occamy_top.sv.tpl
@@ -108,7 +108,6 @@ module ${name}_top
 
   always_comb begin
     soc_ctrl_in = '0;
-    soc_ctrl_in.boot_mode.d = boot_mode_i;
     soc_ctrl_in.chip_id.d = chip_id_i;
   end
 
@@ -386,6 +385,7 @@ module ${name}_top
     .reg_rsp_o ( ${regbus_soc_ctrl.rsp_name()} ),
     .reg2hw_o  ( soc_ctrl_out ),
     .hw2reg_i  ( soc_ctrl_in ),
+    .boot_mode_i ( boot_mode_i),
     .boot_addr_o (boot_addr),
     .event_ecc_rerror_narrow_i(spm_narrow_rerror),
     .event_ecc_rerror_wide_i(spm_wide_rerror),

--- a/hw/occamy/soc_ctrl/occamy_soc_ctrl.sv.tpl
+++ b/hw/occamy/soc_ctrl/occamy_soc_ctrl.sv.tpl
@@ -19,6 +19,7 @@ module occamy_soc_ctrl import occamy_soc_reg_pkg::*; #(
   output occamy_soc_reg2hw_t reg2hw_o, // Write
   input  occamy_soc_hw2reg_t hw2reg_i,
   // Boot addr
+  input logic [1:0] boot_mode_i,
   output logic [${addr_width - 1}:0] boot_addr_o,
   // Events in
   input logic [1:0] event_ecc_rerror_narrow_i,
@@ -68,18 +69,12 @@ module occamy_soc_ctrl import occamy_soc_reg_pkg::*; #(
     .devmode_i ( 1'b1 )
   );
    // boot address
-  logic [${addr_width-1}:0] boot_addr_d, boot_addr_q;
-  logic [${addr_width-1}:0] boot_addr_init;
-  logic [1:0] boot_mode;
-  assign boot_mode = hw2reg_i.boot_mode.d;
-
+   logic [31:0] boot_addr;
   always_comb begin
-    boot_addr_init = (boot_mode == 2'b00)? ${default_boot_addr}:${backup_boot_addr};
-    boot_addr_d = (boot_mode == 2'b00)? ${default_boot_addr}:${backup_boot_addr};
-    boot_addr_o = boot_addr_q;
+      boot_addr = (boot_mode_i == 2'b00)? reg2hw_o.boot_addr_default.q : reg2hw_o.boot_addr_backup.q;
+      boot_addr_o = {${addr_width-32}'h0, boot_addr};
   end
 
-  `FF(boot_addr_q, boot_addr_d, boot_addr_init, clk_i, rst_ni)
 
   prim_intr_hw #(.Width(1)) intr_hw_ecc_narrow_correctable (
     .clk_i,

--- a/hw/occamy/soc_ctrl/occamy_soc_reg.hjson.tpl
+++ b/hw/occamy/soc_ctrl/occamy_soc_reg.hjson.tpl
@@ -83,24 +83,33 @@
       }
     },
 
-    { name: "BOOT_MODE",
-      desc: "Selected boot mode exposed a register.",
+    { name: "BOOT_ADDR_DEFAULT",
+      desc: "Default Boot Address.",
       swaccess: "ro",
-      hwaccess: "hwo",
-      hwqe:     "true",
-      hwext:    "true",
+      hwaccess: "hrw",
       fields: [
-        { bits: "1:0",
-          name: "MODE",
-          desc: "Selected boot mode.",
-          enum: [
-               { value: "0", name: "idle", desc: "Governor idles in bootrom." },
-               { value: "1", name: "serial", desc: "Governor jumps to the base of the serial." },
-               { value: "2", name: "i2c", desc: "Governor tries to boot from I2C." }
-          ]
+        { bits: "31:0",
+          name: "boot_addr_default",
+          desc: "default boot address ${hex_default_boot_addr}",
+          resval: "${int_default_boot_addr}"
         }
       ]
     },
+
+    { name: "BOOT_ADDR_BACKUP",
+      desc: "Backup Boot Address.",
+      swaccess: "ro",
+      hwaccess: "hrw",
+      fields: [
+        { bits: "31:0",
+          name: "boot_addr_backup",
+          desc: "backup boot address ${hex_backup_boot_addr}",
+          resval: "${int_backup_boot_addr}"
+        }
+      ]
+    },
+
+
     { name: "NUM_QUADRANTS",
       desc: "Number of quadrants per chip.",
       swaccess: "ro",

--- a/util/occamygen/occamy.py
+++ b/util/occamygen/occamy.py
@@ -668,8 +668,8 @@ def get_chip_kwargs(soc_wide_xbar, soc_axi_lite_narrow_periph_xbar, occamy_cfg, 
 
 
 def get_ctrl_kwargs(occamy_cfg, name):
-    default_boot_addr = occamy_cfg["peripherals"]["rom"]["address"]
-    backup_boot_addr = occamy_cfg["backup_boot_addr"]
+    default_boot_addr = int(occamy_cfg["peripherals"]["rom"]["address"])
+    backup_boot_addr = int(occamy_cfg["backup_boot_addr"])
     addr_width = occamy_cfg["addr_width"]
 
     hex_default_boot_addr = hex(default_boot_addr)
@@ -680,8 +680,10 @@ def get_ctrl_kwargs(occamy_cfg, name):
     ctrl_kwargs = {
         "name": name,
         "nr_s1_quadrants": occamy_cfg["nr_s1_quadrant"],
-        "default_boot_addr": hex_default_boot_addr,
-        "backup_boot_addr": hex_backup_boot_addr,
+        "hex_default_boot_addr": hex_default_boot_addr,
+        "hex_backup_boot_addr": hex_backup_boot_addr,
+        "int_default_boot_addr": default_boot_addr,
+        "int_backup_boot_addr": backup_boot_addr,
         "occamy_cfg": occamy_cfg,
         "addr_width": addr_width
     }


### PR DESCRIPTION
This PR updates the switching logic of the boot addr.

The previous solution works well on simulation and FPGA. However, when I performed the post-synthesis simulation, I found the boot addr is synthesized as follows


  occamy_soc i_occamy_soc ( .clk_i(clk_i), .rst_ni(n18135), .test_mode_i(
        net24681027), **.boot_addr_i({net24681028, net24681029, net24681030, 
        net24681031, net24681032, net24681033, net24681034, net24681035, 
        net24681036, net24681037, net24681038, net24681039, net24681040, 
        net24681041, net24681042, net24681043, boot_addr[31], net24681044, 
        net24681045, net24681046, net24681047, net24681048, net24681049, 
        boot_addr[24], net24681050, net24681051, net24681052, net24681053, 
        net24681054, net24681055, net24681056, net24681057, net24681058, 
        net24681059, net24681060, net24681061, net24681062, net24681063, 
        net24681064, net24681065, net24681066, net24681067, net24681068, 
        net24681069, net24681070, net24681071, net24681072, net24681073})**,

Only boot_addr[31] and boot_addr[24] are implemented as DFFs and other bits are just wires. 

I have modified the switching logic of the boot addr. Now there are two regs hold the 0x0100_000 and 0x8000_0000 respectively. The external `boot_mode_i `pin will select from those regs.

I am still waiting for the new synthesis results. If the problem solved, I will push to the chip_antwerp and the main.
