### PR TITLE
Add the flag to exclude the tc_clk

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -46,6 +46,11 @@ sources:
     files:
       - target/tapeout/tc_sram/tc_sram_print/tc_sram.sv
       - target/tapeout/tc_sram/tc_sram_print/tc_sram_impl.sv
+
+  - target: all(tech_cells_generic_exclude_tc_clk, synthesis)
+    files:
+      - /users/micas/shares/project_snax/tapeout_modules/hemaia/tc_clk.sv
+      
   - target: all(tech_cells_generic_exclude_tc_sram, any(prep_syn_test,synthesis))
     files:
       - /users/micas/shares/project_snax/tapeout_modules/hemaia/tc_sram_impl.sv

--- a/target/tapeout/Makefile
+++ b/target/tapeout/Makefile
@@ -73,6 +73,7 @@ SYN_BENDER = -t rtl
 SYN_BENDER += -t synthesis
 SYN_BENDER += -t occamy
 SYN_BENDER += -t tech_cells_generic_exclude_tc_sram
+SYN_BENDER += -t tech_cells_generic_exclude_tc_clk
 SYN_BENDER += -t hemaia
 SYN_BENDER += -t tsmc_pad
 SYN_BENDER += $(shell cat ../rtl/src/bender_targets.tmp)


### PR DESCRIPTION
This PR adds the flag to exclude the tc_clk and replace with the vendor tc_clk in the ESAT server