### PR TITLE
Add the obs pins

### DIFF
--- a/hw/occamy/occamy_chip.sv.tpl
+++ b/hw/occamy/occamy_chip.sv.tpl
@@ -13,6 +13,8 @@ import ${name}_pkg::*;
  (
   input  logic        clk_i,
   input  logic        rst_ni,
+  // Obs pins
+  output obs_t        obs_o,
   /// Peripheral clock
   input  logic        clk_periph_i,
   input  logic        rst_periph_ni,
@@ -142,6 +144,7 @@ import ${name}_pkg::*;
   ${name}_top i_${name} (
     .clk_i              (clk_i),
     .rst_ni             (rst_ni),
+    .obs_o              (obs_o),
     .sram_cfgs_i        ('0),
     .clk_periph_i       (clk_periph_i),
     .rst_periph_ni      (rst_periph_ni),

--- a/hw/occamy/occamy_pkg.sv.tpl
+++ b/hw/occamy/occamy_pkg.sv.tpl
@@ -20,11 +20,16 @@ package ${name}_pkg;
   localparam int unsigned NarrowUserWidth = ${narrow_user_width};
   localparam int unsigned WideUserWidth = ${wide_user_width};
 
+  localparam int unsigned ObsPinWidth = ${obs_pin_width};
+
   localparam int unsigned NrClustersS1Quadrant = ${nr_clusters_s1_quadrant};
   localparam int unsigned NrCoresCluster [NrClustersS1Quadrant] = '${core_per_cluster};
   localparam int unsigned NrCoresClusterOffset [NrClustersS1Quadrant] = '${nr_cores_cluster_offset};
   localparam int unsigned NrCoresS1Quadrant = ${nr_cores_quadrant};
 
+  // Obs width typedefine
+  typedef logic [ObsPinWidth-1:0] obs_t [NrClustersS1Quadrant];
+  
   // Memory cut configurations: one per memory parameterization
   // SRAM configurations
   typedef struct packed {

--- a/hw/occamy/occamy_quadrant_s1.sv.tpl
+++ b/hw/occamy/occamy_quadrant_s1.sv.tpl
@@ -34,6 +34,8 @@ module ${name}_quadrant_s1
 (
   input  logic                         clk_i,
   input  logic                         rst_ni,
+  // Obs pins
+  output obs_t                         obs_o,
   input  logic                         test_mode_i,
   input  logic [31:0]                  boot_addr_i,
   input  chip_id_t                     chip_id_i,
@@ -52,6 +54,7 @@ module ${name}_quadrant_s1
   // SRAM configuration
   input  sram_cfg_quadrant_t sram_cfg_i
 );
+
 
  // Calculate cluster base address based on `tile id`.
   addr_t cluster_base_offset;
@@ -240,6 +243,7 @@ module ${name}_quadrant_s1
   ${cluster_name}_wrapper i_${name}_cluster_${i} (
     .clk_i (clk_quadrant_cluster[${i}]),
     .rst_ni (rst_quadrant_n),
+    .obs_o (obs_o[${i}]),
     .meip_i (meip_i[NrCoresClusterOffset[${i}]+:NrCoresCluster[${i}]]),
     .mtip_i (mtip_i[NrCoresClusterOffset[${i}]+:NrCoresCluster[${i}]]),
     .msip_i (msip_i[NrCoresClusterOffset[${i}]+:NrCoresCluster[${i}]]),

--- a/hw/occamy/occamy_soc.sv.tpl
+++ b/hw/occamy/occamy_soc.sv.tpl
@@ -41,6 +41,8 @@ module ${name}_soc
 (
   input  logic        clk_i,
   input  logic        rst_ni,
+  // Obs pins
+  output obs_t        obs_o,
   input  logic        test_mode_i,
   input  logic [${occamy_cfg["addr_width"]-1}:0] boot_addr_i,
   // Peripheral Ports (to AXI-lite Xbar)
@@ -140,6 +142,7 @@ module ${name}_soc
   ${name}_quadrant_s1 i_${name}_quadrant_s1_${i} (
     .clk_i (clk_i),
     .rst_ni (rst_ni),
+    .obs_o (obs_o),
     .test_mode_i (test_mode_i),
     .boot_addr_i (boot_addr_i[31:0]),
     .chip_id_i (8'b0),  // Temporary solution as the Chip ID is not provided yet

--- a/hw/occamy/occamy_top.sv.tpl
+++ b/hw/occamy/occamy_top.sv.tpl
@@ -14,6 +14,8 @@ module ${name}_top
 (
   input  logic        clk_i,
   input  logic        rst_ni,
+  // Obs pins
+  output obs_t        obs_o,
   /// Peripheral clock
   input  logic        clk_periph_i,
   input  logic        rst_periph_ni,
@@ -140,6 +142,7 @@ module ${name}_top
   ${name}_soc i_${name}_soc (
     .clk_i,
     .rst_ni,
+    .obs_o,
     .test_mode_i,
     .boot_addr_i           ( boot_addr                   ),
     .periph_axi_lite_req_o ( periph_axi_lite_soc2per_req ),

--- a/target/rtl/test/testharness.sv.tpl
+++ b/target/rtl/test/testharness.sv.tpl
@@ -134,6 +134,7 @@ module testharness import occamy_pkg::*; (
   occamy_top i_occamy (
     .clk_i,
     .rst_ni,
+    .obs_o (),
     .sram_cfgs_i ('0),
     .clk_periph_i,
     .rst_periph_ni,

--- a/util/occamygen/occamy.py
+++ b/util/occamygen/occamy.py
@@ -515,6 +515,7 @@ def get_cores_cluster_offset(core_per_cluster):
 def get_pkg_kwargs(occamy_cfg, cluster_generators, util, name):
     core_per_cluster_list = [cluster_generator.cfg["nr_cores"]
                              for cluster_generator in cluster_generators]
+    
     cluster_cfg = cluster_generators[0].cfg
     nr_cores_cluster_offset = get_cores_cluster_offset(core_per_cluster_list)
     nr_cores_quadrant = sum(core_per_cluster_list)
@@ -538,6 +539,7 @@ def get_pkg_kwargs(occamy_cfg, cluster_generators, util, name):
         "cluster_base_offset": util.to_sv_hex(cluster_cfg["cluster_base_offset"]),
         "quad_cfg_base_addr": util.to_sv_hex(occamy_cfg["s1_quadrant"]["cfg_base_addr"]),
         "quad_cfg_base_offset": util.to_sv_hex(occamy_cfg["s1_quadrant"]["cfg_base_offset"]),
+        "obs_pin_width": cluster_cfg["observable_pin_width"],
         "hemaia_multichip": occamy_cfg["hemaia_multichip"]
     }
     return pkg_kwargs


### PR DESCRIPTION
This PR adds the obs pins for the hemaia.
1. It will first read the "observable_pin_width" in the cluster cfg than pass the value to generate the
`localparam int unsigned ObsPinWidth = ${obs_pin_width};`
in the occamy_pkg.sv.
Then it will create a type
`// Obs width typedefine`
`typedef logic [ObsPinWidth-1:0] obs_t [NrClustersS1Quadrant];`
2. At the occamy_quadrant_s1.sv, the obs_o of each cluster will tied to the `.obs_o (obs_o[${i}]),`
The obs_o is defined at the output of the quadrant as
`// Obs pins`
`output obs_t                         obs_o,`
3. Then this obs will go through quad->soc->top->chip
4. I also add the mux at the hemaia_chip_top