### PR TITLE
Split the obs_o pins at occamy_chip and occamy_xilinx

### DIFF
--- a/hw/occamy/occamy_chip.sv.tpl
+++ b/hw/occamy/occamy_chip.sv.tpl
@@ -13,8 +13,10 @@ import ${name}_pkg::*;
  (
   input  logic        clk_i,
   input  logic        rst_ni,
-  // Obs pins
-  output obs_t        obs_o,
+  /// Observe Pins
+  %for i in range(obs_num):
+  output logic [${obs_pin_width-1}:0]  obs_${i}_o,
+  %endfor
   /// Peripheral clock
   input  logic        clk_periph_i,
   input  logic        rst_periph_ni,
@@ -140,11 +142,12 @@ import ${name}_pkg::*;
   ///////////////////
   //  Occamy Top   //
   ///////////////////
+  obs_t obs_pin;
 
   ${name}_top i_${name} (
     .clk_i              (clk_i),
     .rst_ni             (rst_ni),
-    .obs_o              (obs_o),
+    .obs_o              (obs_pin),
     .sram_cfgs_i        ('0),
     .clk_periph_i       (clk_periph_i),
     .rst_periph_ni      (rst_periph_ni),
@@ -192,5 +195,9 @@ import ${name}_pkg::*;
     .chip_ctrl_rsp_i    ('0),
     .ext_irq_i          ('0)
   );
+
+  %for i in range(obs_num):
+  assign obs_${i}_o = obs_pin[${i}];
+  %endfor
 
 endmodule

--- a/hw/occamy/occamy_xilinx.sv.tpl
+++ b/hw/occamy/occamy_xilinx.sv.tpl
@@ -16,6 +16,10 @@ import ${name}_pkg::*;
   /// Peripheral clock
   input  logic        clk_periph_i,
   input  logic        rst_periph_ni,
+  /// Observe Pins
+  %for i in range(obs_num):
+  output logic [${obs_pin_width-1}:0]  obs_${i}_o,
+  %endfor
   /// Real-time clock (for time keeping)
   input  logic        rtc_i,
   input  logic        test_mode_i,
@@ -115,7 +119,6 @@ import ${name}_pkg::*;
       bootrom_req_ready_q <= bootrom_req_ready_d;
     end
   end
-
 
   // Occamy top-level
   ${name}_top i_${name} (

--- a/util/occamygen/occamy.py
+++ b/util/occamygen/occamy.py
@@ -482,9 +482,13 @@ def get_quadrant_kwargs(occamy_cfg, cluster_generators, soc_wide_xbar, soc_narro
     return quadrant_kwargs
 
 
-def get_xilinx_kwargs(occamy_cfg, soc_wide_xbar, soc_axi_lite_narrow_periph_xbar, name):
+def get_xilinx_kwargs(occamy_cfg, cluster_generators, soc_wide_xbar, soc_axi_lite_narrow_periph_xbar, name):
+    cluster_cfg = cluster_generators[0].cfg
+
     xilinx_kwargs = {
         "name": name,
+        "obs_pin_width": cluster_cfg["observable_pin_width"],
+        "obs_num": len(occamy_cfg["clusters"]),
         "occamy_cfg": occamy_cfg,
         "soc_wide_xbar": soc_wide_xbar,
         "soc_axi_lite_narrow_periph_xbar": soc_axi_lite_narrow_periph_xbar
@@ -569,39 +573,6 @@ def get_cheader_kwargs(occamy_cfg, cluster_generators, name):
             "Not all cluster base offset in the cluster cfg are equal.")
     cluster_offset = cluster_offset_list[0]
     cluster_addr_width = int(math.log2(cluster_offset))
-    # # The lut here is to provide an easy way to determine the cluster idx based on core idx
-    # # e.g core_per_cluster_list = [2,3]
-    # # core_idx lut    cluster_idx
-    # # 0        lut[0] 0
-    # # 1        lut[1] 0
-    # # 2        lut[2] 1
-    # # 3        lut[3] 1
-    # # 4        lut[4] 1
-    # lut = []
-    # for cluster_num, num_cores in enumerate(core_per_cluster_list):
-    #     lut.extend([cluster_num] * num_cores)
-    # running_sum = []
-    # current_sum = 0
-    # for core in core_per_cluster_list:
-    #     current_sum += core
-    #     running_sum.append(current_sum)
-    # cluster_baseidx = [0] + running_sum[:-1]
-    # # we need to define an array in c header file for each cluster like
-    # # #define N_CORES_PER_CLUSTER {2,3}
-    # # so here we need to take out the value of the core_per_cluster_list
-    # # and join them with commas and then finally concat with {}
-    # nr_cores_per_cluster = "{" + ",".join(map(str, core_per_cluster_list)) + "}"
-    # lut_coreidx_clusteridx = "{" + ",".join(map(str, lut)) + "}"
-    # cluster_baseidx = "{" + ",".join(map(str, cluster_baseidx)) + "}"
-    # cheader_kwargs={
-    #     "name": name,
-    #     "nr_quads": nr_quads,
-    #     "nr_clusters": nr_clusters,
-    #     "nr_cores_per_cluster": nr_cores_per_cluster,
-    #     "lut_coreidx_clusteridx": lut_coreidx_clusteridx,
-    #     "cluster_baseidx": cluster_baseidx,
-    #     "nr_cores": nr_cores
-    # }
     cheader_kwargs = {
         "name": name,
         "nr_quads": nr_quads,
@@ -658,12 +629,15 @@ def get_chip_kwargs(soc_wide_xbar, soc_axi_lite_narrow_periph_xbar, occamy_cfg, 
                              for cluster_generator in cluster_generators]
     nr_cores_quadrant = sum(core_per_cluster_list)
     nr_s1_quadrants = occamy_cfg["nr_s1_quadrant"]
+    cluster_cfg = cluster_generators[0].cfg
     chip_kwargs = {
         "name": name,
         "util": util,
         "occamy_cfg": occamy_cfg,
         "soc_wide_xbar": soc_wide_xbar,
         "soc_axi_lite_narrow_periph_xbar": soc_axi_lite_narrow_periph_xbar,
+        "obs_pin_width": cluster_cfg["observable_pin_width"],
+        "obs_num": len(occamy_cfg["clusters"]),
         "cores": nr_s1_quadrants * nr_cores_quadrant + 1
     }
     return chip_kwargs

--- a/util/occamygen/occamygen.py
+++ b/util/occamygen/occamygen.py
@@ -544,7 +544,7 @@ def main():
     ##################
     if args.xilinx_sv:
         xilinx_kwargs = occamy.get_xilinx_kwargs(
-            occamy_cfg, soc_wide_xbar, soc_axi_lite_narrow_periph_xbar, args.name)
+            occamy_cfg, cluster_generators, soc_wide_xbar, soc_axi_lite_narrow_periph_xbar, args.name)
         write_template(args.xilinx_sv,
                        outdir,
                        fname="{}_xilinx.sv".format(args.name),


### PR DESCRIPTION
This PR splits the customized `obs_t obs_o` output at the occamy_chip and occamy_xilinx level to accommodate the requirements for the FPGA port definition.
The `obs_t obs_o`  is splited to ` logic [7:0]  obs_0_o obs_0_o, obs_1_o, obs_2_o,obs_3_o`. 

1. The number of the obs pin is determined by the extra `obs_num` parameter in the tpl file and the python generator file.
2. The width is determined by the extra `obs_pin_width` parameter in the tpl file and the python generator file.

I will also change the hemaia_top_chip to accommodate this change.