### PR TITLE
Modify loaderscript to increase the size of bss region

### DIFF
--- a/target/sim/sw/host/runtime/host.ld
+++ b/target/sim/sw/host/runtime/host.ld
@@ -16,7 +16,7 @@ SECTIONS
   .appl :
   {
     /*TODO colluca: place stack at end of DRAM*/
-    __stack_pointer$ = ORIGIN(DRAM) + LENGTH(DRAM) - 4;
+    __stack_pointer$ = ORIGIN(DRAM) + LENGTH(DRAM) - 8;
     *(.text.startup)
     *(.text .text.*)
     __SDATA_BEGIN__ = .;

--- a/target/sim/sw/host/runtime/host.ld
+++ b/target/sim/sw/host/runtime/host.ld
@@ -6,7 +6,8 @@ ENTRY(_start)
 
 MEMORY
 {
-    DRAM (rwxa) : ORIGIN = 0x80000000, LENGTH = 0x80000000
+    /* DRAM (rwxa) : ORIGIN = 0x80000000, LENGTH = 0x80000000 */
+    DRAM (rwxa) : ORIGIN = 0x80000000, LENGTH = 0x100000
 }
 
 SECTIONS
@@ -15,11 +16,11 @@ SECTIONS
   .appl :
   {
     /*TODO colluca: place stack at end of DRAM*/
-    __stack_pointer$  = . + 0x70000;
+    __stack_pointer$ = ORIGIN(DRAM) + LENGTH(DRAM) - 4;
     *(.text.startup)
     *(.text .text.*)
     __SDATA_BEGIN__ = .;
-    __global_pointer$ = . + 0x7f0;
+    __global_pointer$ = . + 0x800;
     *(.sdata)
     *(.srodata.cst16) *(.srodata.cst8) *(.srodata.cst4) *(.srodata.cst2) *(.srodata .srodata.*)
     *(.sdata .sdata.* .gnu.linkonce.s.*)


### PR DESCRIPTION
This PR modifies the loaderscript of the CVA6 Program to fully utilize the 1MB on-chip SRAM. 