### PR TITLE
Add multichip support for SPI Slave

### DIFF
--- a/hw/occamy/occamy_top.sv.tpl
+++ b/hw/occamy/occamy_top.sv.tpl
@@ -357,6 +357,7 @@ module ${name}_top
   ) i_spi_slave (
     .clk_i(${axi_spi_slave.clk}),
     .rst_ni(${axi_spi_slave.rst}),
+    .chip_id_i(chip_id_i),
     .axi_lite_req_o(${axi_spi_slave.req_name()}),
     .axi_lite_rsp_i(${axi_spi_slave.rsp_name()}),
     .spi_sclk_i(spis_sck_i),


### PR DESCRIPTION
Add **chip_id_i** pin for **occamy_spi_slave** module. This PR is together with the update of SPI Slave: https://github.com/KULeuven-MICAS/hemaia_axi_spi_slave/commit/50f8e800f0588cdc373a4a630f937b4fa88a0f69