### PR TITLE
Fix SPI Slave

### DIFF
--- a/hw/occamy/occamy_top.sv.tpl
+++ b/hw/occamy/occamy_top.sv.tpl
@@ -340,6 +340,7 @@ module ${name}_top
   ) i_spi_slave (
     .clk_i(${axi_spi_slave.clk}),
     .rst_ni(${axi_spi_slave.rst}),
+    .chip_id_i('0),
     .axi_lite_req_o(${axi_spi_slave.req_name()}),
     .axi_lite_rsp_i(${axi_spi_slave.rsp_name()}),
     .spi_sclk_i(spis_sck_i),


### PR DESCRIPTION
Due to the update of SPI Slave: https://github.com/KULeuven-MICAS/hemaia_axi_spi_slave/commit/50f8e800f0588cdc373a4a630f937b4fa88a0f69, this PR updates the instantiation of the module for the correct functionality. 