### PR TITLE
Swap order of cgra and gemm in config file

### DIFF
--- a/target/rtl/cfg/hemaia_tapeout.hjson
+++ b/target/rtl/cfg/hemaia_tapeout.hjson
@@ -108,8 +108,8 @@
       cfg_base_offset: 65536 // 0x10000
     },
     clusters:[
-      "snax_KUL_cluster",
       "snax_cgra_cluster",
+      "snax_KUL_cluster",
       "snax_hypercorex_cluster",
       "snax_dimc_cluster"
     ],


### PR DESCRIPTION
This PR is a tapeout fix, so the order of CGRA and GeMM were swapped. To avoid changing order in PnR, we just swap it here.
It's a minor fix.

The swap happened in PR #91 