### PR TITLE
add the support for configure the clkgen_trim

### DIFF
--- a/hw/occamy/occamy_chip.sv.tpl
+++ b/hw/occamy/occamy_chip.sv.tpl
@@ -23,6 +23,8 @@ import ${name}_pkg::*;
   input  logic        test_mode_i,
   input  logic [1:0]  chip_id_i,
   input  logic [1:0]  boot_mode_i,
+  // Clk gen trim bits
+  output logic [8:0]  clk_gen_trim_bits_o,
   // `uart` Interface
   output logic        uart_tx_o,
   input  logic        uart_rx_i,
@@ -152,6 +154,7 @@ import ${name}_pkg::*;
     .test_mode_i        (test_mode_i),
     .chip_id_i          (chip_id_i),
     .boot_mode_i        (boot_mode_i),
+    .clk_gen_trim_bits_o (clk_gen_trim_bits_o),
     .uart_tx_o          (uart_tx_o),
     .uart_cts_ni        (uart_cts_ni),
     .uart_rts_no        (uart_rts_no),

--- a/hw/occamy/occamy_top.sv.tpl
+++ b/hw/occamy/occamy_top.sv.tpl
@@ -24,6 +24,8 @@ module ${name}_top
   input  logic        test_mode_i,
   input  logic [1:0]  chip_id_i,
   input  logic [1:0]  boot_mode_i,
+  // Clk gen trim bits
+  output logic [8:0]  clk_gen_trim_bits_o,
   // `uart` Interface
   output logic        uart_tx_o,
   input  logic        uart_rx_i,
@@ -389,8 +391,9 @@ module ${name}_top
     .reg_rsp_o ( ${regbus_soc_ctrl.rsp_name()} ),
     .reg2hw_o  ( soc_ctrl_out ),
     .hw2reg_i  ( soc_ctrl_in ),
-    .boot_mode_i ( boot_mode_i),
-    .boot_addr_o (boot_addr),
+    .boot_mode_i ( boot_mode_i ),
+    .boot_addr_o ( boot_addr ),
+    .clk_gen_trim_bits_o ( clk_gen_trim_bits_o ),
     .event_ecc_rerror_narrow_i(spm_narrow_rerror),
     .event_ecc_rerror_wide_i(spm_wide_rerror),
     .intr_ecc_narrow_uncorrectable_o(irq.ecc_narrow_uncorrectable),

--- a/hw/occamy/soc_ctrl/occamy_soc_ctrl.sv.tpl
+++ b/hw/occamy/soc_ctrl/occamy_soc_ctrl.sv.tpl
@@ -21,6 +21,8 @@ module occamy_soc_ctrl import occamy_soc_reg_pkg::*; #(
   // Boot addr
   input logic [1:0] boot_mode_i,
   output logic [${addr_width - 1}:0] boot_addr_o,
+  // clk trim bits
+  output logic [8:0] clk_gen_trim_bits_o,
   // Events in
   input logic [1:0] event_ecc_rerror_narrow_i,
   input logic [1:0] event_ecc_rerror_wide_i,
@@ -74,7 +76,10 @@ module occamy_soc_ctrl import occamy_soc_reg_pkg::*; #(
       boot_addr = (boot_mode_i == 2'b00)? reg2hw_o.boot_addr_default.q : reg2hw_o.boot_addr_backup.q;
       boot_addr_o = {${addr_width-32}'h0, boot_addr};
   end
-
+  // clk trim bits
+  always_comb begin
+    clk_gen_trim_bits_o = reg2hw_o.clk_trim.q[8:0];
+  end
 
   prim_intr_hw #(.Width(1)) intr_hw_ecc_narrow_correctable (
     .clk_i,

--- a/hw/occamy/soc_ctrl/occamy_soc_reg.hjson.tpl
+++ b/hw/occamy/soc_ctrl/occamy_soc_reg.hjson.tpl
@@ -64,6 +64,18 @@
         }
       ]
     },
+    { name: "CLK_TRIM",
+      desc: "TRIM bits for CLK GEN.",
+      swaccess: "rw",
+      hwaccess: "hrw",
+      fields: [
+        { bits: "31:0",
+          name: "clk_trim",
+          desc: "default trim bits are 9'b0_0011_0000",
+          resval: "48"
+        }
+      ]
+    },
     { multireg:
       { name: "SCRATCH",
         desc: "Scratch register for SW to write to.",


### PR DESCRIPTION
This PR adds the support for configure the clk_gen_trim at the SOC_CTRL
A new field of clk_trim is added to `hw/occamy/soc_ctrl/occamy_soc_reg.hjson.tpl`, and this will be compiled to generate the corresponding reg at SOC_CTRL. By doing so, we can control the freq of the vendor-provided clk gen IP. 