### PR TITLE
Bender: fix snitch version to hemaia_tapeout

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -29,7 +29,7 @@ dependencies:
   cva6:                   { path: hw/vendor/openhwgroup_cva6                                                }
   opentitan_peripherals:  { path: hw/vendor/pulp_platform_opentitan_peripherals                             }
   register_interface:     { git:  https://github.com/pulp-platform/register_interface.git, version: 0.3.8   }
-  snitch_cluster:         { git:  https://github.com/KULeuven-MICAS/snax_cluster.git,      rev:        main }
+  snitch_cluster:         { git:  https://github.com/KULeuven-MICAS/snax_cluster.git,      rev:        hemaia_tapeout }
   tech_cells_generic:     { git:  https://github.com/KULeuven-MICAS/tech_cells_generic.git, version: 0.2.15 }
   cluster_icache:         { git:  https://github.com/KULeuven-MICAS/cluster_icache.git,     rev:  main }
   hemaia_axi_spi_slave:    { git: https://github.com/KULeuven-MICAS/hemaia_axi_spi_slave.git, rev: main }


### PR DESCRIPTION
This PR simply freezes the snitch_cluster to pull from the `hemaia_tapeout` tag only.