### PR TITLE
Fix Makefile bug in offload program

### DIFF
--- a/target/rtl/cfg/hemaia.hjson
+++ b/target/rtl/cfg/hemaia.hjson
@@ -181,7 +181,7 @@
                 length: 4096, // 4 kiB 0x1000
             },
             {
-                name: "chip_ctrl",
+                name: "hemaia_clk_rst_controller",
                 address: 33574912, // 0x0200_5000
                 length: 4096, // 4 kiB 0x1000
             },

--- a/target/sim/.gitignore
+++ b/target/sim/.gitignore
@@ -4,8 +4,9 @@
 /work/
 /work-vsim/
 /work-vlt/
-/*.log
-/*.jou
+**/*.tmp
+**/*.log
+**/*.jou
 /.*_targets_group
 /sw/**/build/
 /runs/

--- a/target/sim/sw/device/Makefile
+++ b/target/sim/sw/device/Makefile
@@ -7,9 +7,8 @@
 # Add user applications to APPS variable automatically. This is located in the apps directory with depth of 2.
 
 # Now we only compile the snax apps
-APPDIR  = $(shell find apps/snax -mindepth 1 -maxdepth 1 -type d)
+APPDIR  = $(shell cat app_list.tmp)
 TARGET ?= all
-
 
 RTDIR    = math
 RTDIR   += runtime

--- a/target/sim/sw/host/Makefile
+++ b/target/sim/sw/host/Makefile
@@ -6,10 +6,10 @@
 
 # Add user applications to APPS variable
 APPS  = hello_world
-APPS += hemaia_d2d_link_configurator
 APPS += hemaia_clk_rst_configurator
 ifneq ($(findstring chiplet,$(CFG_OVERRIDE)),)
 # If chiplet cfg is used, offloaf_multichip is compiled with the support to execute applications on cores at different chips
+APPS += hemaia_d2d_link_configurator
 APPS += offload_multichip
 APPS += multichip_sync
 else

--- a/target/sim/sw/host/apps/offload/Makefile
+++ b/target/sim/sw/host/apps/offload/Makefile
@@ -32,15 +32,15 @@ RUNTIME_DIR = $(abspath $(HOST_DIR)/runtime)
 DEVICE_DIR  = $(abspath $(HOST_DIR)/../device)
 
 # now we only include the snax app
-DEVICE_APPS += snax/snax-test-integration
-DEVICE_APPS += snax/snax-xdma-maxpool
-DEVICE_APPS += snax/snax-xdma-memset
-DEVICE_APPS += snax/snax-xdma-multicast
-DEVICE_APPS += snax/snax-xdma-copy
-DEVICE_APPS += snax/snax-xdma-transpose
-DEVICE_APPS += snax/snax-xdma-reshape
-DEVICE_APPS += snax/snax-axi-torture
-DEVICE_APPS += snax/snax-axi-torture-devil
+DEVICE_APPS += apps/snax/snax-test-integration
+DEVICE_APPS += apps/snax/snax-xdma-maxpool
+DEVICE_APPS += apps/snax/snax-xdma-memset
+DEVICE_APPS += apps/snax/snax-xdma-multicast
+DEVICE_APPS += apps/snax/snax-xdma-copy
+DEVICE_APPS += apps/snax/snax-xdma-transpose
+DEVICE_APPS += apps/snax/snax-xdma-reshape
+DEVICE_APPS += apps/snax/snax-axi-torture
+DEVICE_APPS += apps/snax/snax-axi-torture-devil
 
 # Dependencies
 INCDIRS += $(RUNTIME_DIR)
@@ -75,7 +75,7 @@ RISCV_LDFLAGS += -lgcc
 RISCV_LDFLAGS += -T$(LINKER_SCRIPT)
 
 # Device binaries
-DEVICE_BUILDDIRS = $(addsuffix /build, $(addprefix $(DEVICE_DIR)/apps/, $(DEVICE_APPS)))
+DEVICE_BUILDDIRS = $(addsuffix /build, $(addprefix $(DEVICE_DIR)/, $(DEVICE_APPS)))
 
 ###########
 # Outputs #
@@ -95,8 +95,11 @@ FINAL_OUTPUTS   = $(ELFS) $(DUMPS) $(DWARFS)
 # Rules #
 #########
 
+$(DEVICE_DIR)/app_list.tmp:
+	echo "$(DEVICE_APPS)" > $(DEVICE_DIR)/app_list.tmp
+
 .PHONY: partial-build
-partial-build: $(PARTIAL_OUTPUTS)
+partial-build: $(DEVICE_DIR)/app_list.tmp $(PARTIAL_OUTPUTS)
 
 .PHONY: finalize-build
 finalize-build: $(FINAL_OUTPUTS)
@@ -126,8 +129,8 @@ $(PARTIAL_DUMP): $(PARTIAL_ELF) | $(BUILDDIR)
 	$(RISCV_OBJDUMP) -D $< > $@
 
 # Device object relocation address
-.PHONY: $(DEVICE_DIR)/apps/%/build/origin.ld
-$(DEVICE_DIR)/apps/%/build/origin.ld: $(PARTIAL_ELF) | $(DEVICE_DIR)/apps/%/build
+.PHONY: $(DEVICE_DIR)/%/build/origin.ld
+$(DEVICE_DIR)/%/build/origin.ld: $(PARTIAL_ELF) | $(DEVICE_DIR)/%/build
 	@RELOC_ADDR=$$($(RISCV_OBJDUMP) -t $< | grep snitch_main | cut -c9-16); \
 	echo "Writing device object relocation address 0x$$RELOC_ADDR to $@"; \
 	echo "L3_ORIGIN = 0x$$RELOC_ADDR;" > $@
@@ -139,7 +142,7 @@ $(DEVICE_DIR)/apps/%/build/origin.ld: $(PARTIAL_ELF) | $(DEVICE_DIR)/apps/%/buil
 #
 # This approach is required cause you can't use multiple %-signs in a prerequisite
 define elf_rule_template =
-    $$(BUILDDIR)/$$(APP)-$(notdir $(1)).elf: $$(DEVICE_DIR)/apps/$(1)/build/$(notdir $(1)).bin $$(DEP) $$(LD_SRCS) | $$(BUILDDIR)
+    $$(BUILDDIR)/$$(APP)-$(notdir $(1)).elf: $$(DEVICE_DIR)/$(1)/build/$(notdir $(1)).bin $$(DEP) $$(LD_SRCS) | $$(BUILDDIR)
 		$$(RISCV_CC) $$(RISCV_CFLAGS) -DDEVICEBIN=\"$$<\" $$(RISCV_LDFLAGS) $$(SRCS) -o $$@
 endef
 $(foreach f,$(DEVICE_APPS),$(eval $(call elf_rule_template,$(f))))

--- a/target/sim/sw/host/apps/offload_multichip/Makefile
+++ b/target/sim/sw/host/apps/offload_multichip/Makefile
@@ -32,16 +32,16 @@ RUNTIME_DIR = $(abspath $(HOST_DIR)/runtime)
 DEVICE_DIR  = $(abspath $(HOST_DIR)/../device)
 
 # now we only include the snax app
-DEVICE_APPS += snax/snax-test-integration
-DEVICE_APPS += snax/snax-xdma-maxpool
-DEVICE_APPS += snax/snax-xdma-memset
-DEVICE_APPS += snax/snax-xdma-multicast
-DEVICE_APPS += snax/snax-xdma-copy
-DEVICE_APPS += snax/snax-xdma-transpose
-DEVICE_APPS += snax/snax-xdma-reshape
-DEVICE_APPS += snax/snax-axi-torture
-DEVICE_APPS += snax/snax-axi-torture-devil
-DEVICE_APPS += snax/snax-xdma-multicast-chiplet
+DEVICE_APPS += apps/snax/snax-test-integration
+DEVICE_APPS += apps/snax/snax-xdma-maxpool
+DEVICE_APPS += apps/snax/snax-xdma-memset
+DEVICE_APPS += apps/snax/snax-xdma-multicast
+DEVICE_APPS += apps/snax/snax-xdma-copy
+DEVICE_APPS += apps/snax/snax-xdma-transpose
+DEVICE_APPS += apps/snax/snax-xdma-reshape
+DEVICE_APPS += apps/snax/snax-axi-torture
+DEVICE_APPS += apps/snax/snax-axi-torture-devil
+DEVICE_APPS += apps/snax/snax-xdma-multicast-chiplet
 
 # Dependencies
 INCDIRS += $(RUNTIME_DIR)
@@ -77,7 +77,7 @@ RISCV_LDFLAGS += -lgcc
 RISCV_LDFLAGS += -T$(LINKER_SCRIPT)
 
 # Device binaries
-DEVICE_BUILDDIRS = $(addsuffix /build, $(addprefix $(DEVICE_DIR)/apps/, $(DEVICE_APPS)))
+DEVICE_BUILDDIRS = $(addsuffix /build, $(addprefix $(DEVICE_DIR)/, $(DEVICE_APPS)))
 
 ###########
 # Outputs #
@@ -97,8 +97,11 @@ FINAL_OUTPUTS   = $(ELFS) $(DUMPS) $(DWARFS)
 # Rules #
 #########
 
+$(DEVICE_DIR)/app_list.tmp:
+	echo "$(DEVICE_APPS)" > $(DEVICE_DIR)/app_list.tmp
+
 .PHONY: partial-build
-partial-build: $(PARTIAL_OUTPUTS)
+partial-build: $(DEVICE_DIR)/app_list.tmp $(PARTIAL_OUTPUTS)
 
 .PHONY: finalize-build
 finalize-build: $(FINAL_OUTPUTS)
@@ -128,8 +131,8 @@ $(PARTIAL_DUMP): $(PARTIAL_ELF) | $(BUILDDIR)
 	$(RISCV_OBJDUMP) -D $< > $@
 
 # Device object relocation address
-.PHONY: $(DEVICE_DIR)/apps/%/build/origin.ld
-$(DEVICE_DIR)/apps/%/build/origin.ld: $(PARTIAL_ELF) | $(DEVICE_DIR)/apps/%/build
+.PHONY: $(DEVICE_DIR)/%/build/origin.ld
+$(DEVICE_DIR)/%/build/origin.ld: $(PARTIAL_ELF) | $(DEVICE_DIR)/%/build
 	@RELOC_ADDR=$$($(RISCV_OBJDUMP) -t $< | grep snitch_main | cut -c9-16); \
 	echo "Writing device object relocation address 0x$$RELOC_ADDR to $@"; \
 	echo "L3_ORIGIN = 0x$$RELOC_ADDR;" > $@
@@ -141,7 +144,7 @@ $(DEVICE_DIR)/apps/%/build/origin.ld: $(PARTIAL_ELF) | $(DEVICE_DIR)/apps/%/buil
 #
 # This approach is required cause you can't use multiple %-signs in a prerequisite
 define elf_rule_template =
-    $$(BUILDDIR)/$$(APP)-$(notdir $(1)).elf: $$(DEVICE_DIR)/apps/$(1)/build/$(notdir $(1)).bin $$(DEP) $$(LD_SRCS) | $$(BUILDDIR)
+    $$(BUILDDIR)/$$(APP)-$(notdir $(1)).elf: $$(DEVICE_DIR)/$(1)/build/$(notdir $(1)).bin $$(DEP) $$(LD_SRCS) | $$(BUILDDIR)
 		$$(RISCV_CC) $$(RISCV_CFLAGS) -DDEVICEBIN=\"$$<\" $$(RISCV_LDFLAGS) $$(SRCS) -o $$@
 endef
 $(foreach f,$(DEVICE_APPS),$(eval $(call elf_rule_template,$(f))))


### PR DESCRIPTION
This PR solves a long-lasting problem that uses **find** command to collect all SNAX binaries' directory. 