### PR TITLE
Add NoC Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
   #################################################
 
   hemaia-verilator:
-    name: Simulation with Verilator
+    name: Simulation HeMAiA XBar with Verilator
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/kuleuven-micas/snax@sha256:4ff37cad4e85d6a898cda3232ee04a1210833eb4618d1f1fd183201c03c4c57c
@@ -46,6 +46,27 @@ jobs:
           make sw CFG_OVERRIDE=target/rtl/cfg/hemaia_ci.hjson -j$(nproc)
           make bootrom CFG_OVERRIDE=target/rtl/cfg/hemaia_ci.hjson -j$(nproc)
           make rtl CFG_OVERRIDE=target/rtl/cfg/hemaia_ci.hjson
+          make hemaia_system_vlt -j$(nproc)
+          make -C target/sim_chip/apps apps
+      - name: Run Tests
+        working-directory: target/sim_chip/automation/ci
+        run: |
+          python3 start.py
+
+  hemaia-noc-verilator:
+    name: Simulation HeMAiA NoC with Verilator
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/kuleuven-micas/snax@sha256:4ff37cad4e85d6a898cda3232ee04a1210833eb4618d1f1fd183201c03c4c57c
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: "recursive"
+      - name: Compile everything
+        run: |
+          make sw CFG_OVERRIDE=target/rtl/cfg/hemaia_noc.hjson -j$(nproc)
+          make bootrom CFG_OVERRIDE=target/rtl/cfg/hemaia_noc.hjson -j$(nproc)
+          make rtl CFG_OVERRIDE=target/rtl/cfg/hemaia_noc.hjson
           make hemaia_system_vlt -j$(nproc)
           make -C target/sim_chip/apps apps
       - name: Run Tests

--- a/Bender.yml
+++ b/Bender.yml
@@ -29,12 +29,12 @@ dependencies:
   cva6:                   { path: hw/vendor/openhwgroup_cva6                                                    }
   opentitan_peripherals:  { path: hw/vendor/pulp_platform_opentitan_peripherals                                 }
   register_interface:     { git:  https://github.com/pulp-platform/register_interface.git,     version: 0.3.8   }
-  snitch_cluster:         { git:  https://github.com/KULeuven-MICAS/snax_cluster.git,          rev:     main         }
+  snitch_cluster:         { git:  https://github.com/KULeuven-MICAS/snax_cluster.git,          rev:     main    }
   tech_cells_generic:     { git:  https://github.com/KULeuven-MICAS/tech_cells_generic.git,   version: 0.2.16   }
-  cluster_icache:         { git:  https://github.com/KULeuven-MICAS/cluster_icache.git,       rev:     main          }
-  hemaia_axi_spi_slave:   { git:  https://github.com/KULeuven-MICAS/hemaia_axi_spi_slave.git,  rev:     main         }
-  hemaia_d2d_link:        { git:  https://github.com/IveanEx/hemaia_d2d_link.git,              rev:     main         }
-  floo_noc:                { git: https://github.com/Konste11ation/FlooNoC,              rev:  fanchen/floonoc-chiplet-adapt}
+  cluster_icache:         { git:  https://github.com/KULeuven-MICAS/cluster_icache.git,        rev:     main    }
+  hemaia_axi_spi_slave:   { git:  https://github.com/KULeuven-MICAS/hemaia_axi_spi_slave.git,  rev:     main    }
+  hemaia_d2d_link:        { git:  https://github.com/IveanEx/hemaia_d2d_link.git,              rev:     main    }
+  floo_noc:               { git: https://github.com/KULeuven-MICAS/FlooNoC,                    rev:     main    }
 
 workspace:
   package_links:

--- a/Bender.yml
+++ b/Bender.yml
@@ -73,11 +73,13 @@ sources:
   - target: snax_minimal_cluster
     files:
       - deps/snitch_cluster/target/snitch_cluster/generated/snax_minimal_cluster_wrapper.sv
+
   # Targets for the occamy NoC
   - target: occamy_noc
     files:
       - target/rtl/src/floo_quad_mesh_xy_noc_pkg.sv
       - target/rtl/src/floo_quad_mesh_xy_noc.sv
+
   # auto-generated soc
   - target: occamy
     files:
@@ -107,6 +109,7 @@ sources:
       - target/rtl/src/occamy_soc.sv
       - target/rtl/src/occamy_top.sv
       - target/rtl/src/occamy_cva6.sv
+
   # HeMAiA bootrom
   - target: all(hemaia, not(simulation_hemaia))
     files:
@@ -143,7 +146,6 @@ sources:
     files:
       - target/rtl/test/uartdpi/uartdpi.sv
       - target/sim_chip/testharness/testharness.sv
-
 
   - target: tsmc_pad
     files:

--- a/Bender.yml
+++ b/Bender.yml
@@ -34,6 +34,7 @@ dependencies:
   cluster_icache:         { git:  https://github.com/KULeuven-MICAS/cluster_icache.git,     rev:     main    }
   hemaia_axi_spi_slave:   { git: https://github.com/KULeuven-MICAS/hemaia_axi_spi_slave.git,rev:     main    }
   hemaia_d2d_link:        { git: https://github.com/IveanEx/hemaia_d2d_link.git,            rev:     main    }
+  floo_noc:                { git: https://github.com/Konste11ation/FlooNoC,              rev:  fanchen/floonoc-chiplet-adapt}
 
 workspace:
   package_links:
@@ -97,6 +98,8 @@ sources:
 
       # occamy
       - target/rtl/src/occamy_pkg.sv
+      - target/rtl/src/floo_quad_mesh_xy_noc_pkg.sv
+      - target/rtl/src/floo_quad_mesh_xy_noc.sv
       - target/rtl/src/occamy_quadrant_s1_ctrl.sv
       - target/rtl/src/occamy_quadrant_s1.sv
       - target/rtl/src/occamy_soc.sv

--- a/Bender.yml
+++ b/Bender.yml
@@ -19,21 +19,21 @@ package:
     - Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
 
 dependencies:
-  apb:                    { git:  https://github.com/pulp-platform/apb.git,                 version:   0.2.0 }
-  apb_timer:              { git:  https://github.com/pulp-platform/apb_timer.git,           rev:     0cbc6cbc26c94b8e3bf27cc058c48ef89ea3d4c3 }
-  apb_uart:               { git:  https://github.com/pulp-platform/apb_uart.git,            rev:     b6145341df79137ac584c83e9c081f80a7a40440 }
-  axi:                    { path: hw/vendor/pulp_platform_axi                                                }
-  axi_tlb:                { path: hw/vendor/pulp_platform_axi_tlb                                            }
-  clint:                  { git:  https://github.com/pulp-platform/clint.git,               rev:     v0.1.0  }
-  common_cells:           { git:  https://github.com/pulp-platform/common_cells.git,        rev:     v1.28.0 }
-  cva6:                   { path: hw/vendor/openhwgroup_cva6                                                 }
-  opentitan_peripherals:  { path: hw/vendor/pulp_platform_opentitan_peripherals                              }
-  register_interface:     { git:  https://github.com/pulp-platform/register_interface.git,  version: 0.3.8   }
-  snitch_cluster:         { git:  https://github.com/KULeuven-MICAS/snax_cluster.git,       rev:     main    }
-  tech_cells_generic:     { git:  https://github.com/KULeuven-MICAS/tech_cells_generic.git, version: 0.2.16  }
-  cluster_icache:         { git:  https://github.com/KULeuven-MICAS/cluster_icache.git,     rev:     main    }
-  hemaia_axi_spi_slave:   { git: https://github.com/KULeuven-MICAS/hemaia_axi_spi_slave.git,rev:     main    }
-  hemaia_d2d_link:        { git: https://github.com/IveanEx/hemaia_d2d_link.git,            rev:     main    }
+  apb:                    { git:  https://github.com/pulp-platform/apb.git,                    version:   0.2.0   }
+  apb_timer:              { git:  https://github.com/pulp-platform/apb_timer.git,              rev:     0cbc6cbc26c94b8e3bf27cc058c48ef89ea3d4c3 }
+  apb_uart:               { git:  https://github.com/pulp-platform/apb_uart.git,               rev:     b6145341df79137ac584c83e9c081f80a7a40440 }
+  axi:                    { path: hw/vendor/pulp_platform_axi                                                   }
+  axi_tlb:                { path: hw/vendor/pulp_platform_axi_tlb                                               }
+  clint:                  { git:  https://github.com/pulp-platform/clint.git,                  rev:     v0.1.0  }
+  common_cells:           { git:  https://github.com/pulp-platform/common_cells.git,           rev:     v1.28.0 }
+  cva6:                   { path: hw/vendor/openhwgroup_cva6                                                    }
+  opentitan_peripherals:  { path: hw/vendor/pulp_platform_opentitan_peripherals                                 }
+  register_interface:     { git:  https://github.com/pulp-platform/register_interface.git,     version: 0.3.8   }
+  snitch_cluster:         { git:  https://github.com/KULeuven-MICAS/snax_cluster.git,          rev:     main         }
+  tech_cells_generic:     { git:  https://github.com/KULeuven-MICAS/tech_cells_generic.git,   version: 0.2.16   }
+  cluster_icache:         { git:  https://github.com/KULeuven-MICAS/cluster_icache.git,       rev:     main          }
+  hemaia_axi_spi_slave:   { git:  https://github.com/KULeuven-MICAS/hemaia_axi_spi_slave.git,  rev:     main         }
+  hemaia_d2d_link:        { git:  https://github.com/IveanEx/hemaia_d2d_link.git,              rev:     main         }
   floo_noc:                { git: https://github.com/Konste11ation/FlooNoC,              rev:  fanchen/floonoc-chiplet-adapt}
 
 workspace:
@@ -73,7 +73,11 @@ sources:
   - target: snax_minimal_cluster
     files:
       - deps/snitch_cluster/target/snitch_cluster/generated/snax_minimal_cluster_wrapper.sv
-
+  # Targets for the occamy NoC
+  - target: occamy_noc
+    files:
+      - target/rtl/src/floo_quad_mesh_xy_noc_pkg.sv
+      - target/rtl/src/floo_quad_mesh_xy_noc.sv
   # auto-generated soc
   - target: occamy
     files:
@@ -98,14 +102,11 @@ sources:
 
       # occamy
       - target/rtl/src/occamy_pkg.sv
-      - target/rtl/src/floo_quad_mesh_xy_noc_pkg.sv
-      - target/rtl/src/floo_quad_mesh_xy_noc.sv
       - target/rtl/src/occamy_quadrant_s1_ctrl.sv
       - target/rtl/src/occamy_quadrant_s1.sv
       - target/rtl/src/occamy_soc.sv
       - target/rtl/src/occamy_top.sv
       - target/rtl/src/occamy_cva6.sv
-
   # HeMAiA bootrom
   - target: all(hemaia, not(simulation_hemaia))
     files:

--- a/docs/schema/occamy.schema.json
+++ b/docs/schema/occamy.schema.json
@@ -30,9 +30,24 @@
         },
         "narrow_xbar_slv_id_width": {
             "type": "integer",
-            "description": "ID width of narrow crossbar slave ports.",
+            "description": "ID width of narrow soc crossbar slave ports.",
             "default": 4
         },
+        "narrow_xbar_slv_user_width": {
+            "type": "integer",
+            "description": "User width of narrow soc crossbar slave ports.",
+            "default": 3
+        },
+        "wide_xbar_slv_id_width": {
+            "type": "integer",
+            "description": "ID width of wide soc crossbar slave ports.",
+            "default": 4
+        },        
+        "wide_xbar_slv_user_width": {
+            "type": "integer",
+            "description": "User width of wide soc crossbar slave ports.",
+            "default": 1
+        },        
         "nr_s1_quadrant": {
             "title": "Number of S1 Quadrants",
             "type": "integer",
@@ -313,6 +328,36 @@
                     "default": 4,
                     "description": "Number of clusters in an S1 quadrant."
                 },
+                "noc_cfg": {
+                    "type": "object",
+                    "description": "Mesh NoC configuration.",
+                    "properties": {
+                        "en_floonoc": {
+                            "type": "boolean",
+                            "description": "Enable the FlooNoC",
+                            "default": false
+                        },
+                        "routing_algo": {
+                            "type": "string",
+                            "description": "The Routing Algorithm",
+                            "enum": ["XY", "SRC", "ID"],
+                            "default": "XY"
+                        },
+                        "noc_name": {
+                            "type": "string",
+                            "description": "The Generated NoC RTL TOP Name"
+                        },
+                        "noc_array": {
+                            "type": "array",
+                            "description": "The noc array dimension, first is x_num, second is y_num",
+                            "items": {
+                                "type": "integer"
+                            },
+                            "minItems": 2,
+                            "maxItems": 2
+                        }
+                    }
+                },                
                 "ro_cache_cfg": {
                     "type": "object",
                     "description": "Constant cache configuration.",
@@ -349,6 +394,11 @@
                     "description": "ID width of wide quadrant crossbar slave ports.",
                     "default": 3
                 },
+                "wide_xbar_slv_user_width": {
+                    "type": "integer",
+                    "description": "User width of wide quadrant crossbar slave ports.",
+                    "default": 1
+                },
                 "narrow_xbar": {
                     "$ref": "http://pulp-platform.org/occamy/axi_xbar.schema.json"
                 },
@@ -356,6 +406,11 @@
                     "type": "integer",
                     "description": "ID width of narrow quadrant crossbar slave ports.",
                     "default": 4
+                },
+                "narrow_xbar_slv_user_width": {
+                    "type": "integer",
+                    "description": "User width of narrow quadrant crossbar slave ports.",
+                    "default": 2
                 },
                 "cfg_base_addr": {
                     "type": "integer",

--- a/hw/occamy/occamy_quadrant_s1.sv.tpl
+++ b/hw/occamy/occamy_quadrant_s1.sv.tpl
@@ -15,6 +15,10 @@
   cuts_wideisolate_with_wideiwc_in = 1
   cuts_wideiwc_with_wideout = 1
   nr_clusters = len(occamy_cfg["clusters"])
+  en_floonoc = occamy_cfg["s1_quadrant"]["noc_cfg"]["en_floonoc"]
+  noc_name = occamy_cfg["s1_quadrant"]["noc_cfg"]["noc_name"]
+  x_num = occamy_cfg["s1_quadrant"]["noc_cfg"]["noc_array"][0]
+  y_num = occamy_cfg["s1_quadrant"]["noc_cfg"]["noc_array"][1]
   wide_trans = int(occamy_cfg["s1_quadrant"]["wide_trans"])
   narrow_trans = int(occamy_cfg["s1_quadrant"]["narrow_trans"])
   ro_cache_cfg = occamy_cfg["s1_quadrant"].get("ro_cache_cfg", {})
@@ -31,6 +35,9 @@
 /// Occamy Stage 1 Quadrant
 module ${name}_quadrant_s1
   import ${name}_pkg::*;
+  %if en_floonoc:
+  import floo_${noc_name}_noc_pkg::*;
+  %endif
 (
   input  logic                         clk_i,
   input  logic                         rst_ni,
@@ -81,14 +88,83 @@ module ${name}_quadrant_s1
   tlb_entry_t [${wide_tlb_entries-1}:0] wide_tlb_entries;
   % endif
 
+  ///////////////////////
+  //   INTERCONNECTS   //
+  ///////////////////////
+%if en_floonoc:
+  //////////////
+  // FlooNoC  //
+  //////////////
+
+  ///Address Map of the 'floo_${noc_name}_noc' NoC.
+  floo_${noc_name}_noc_pkg::sam_rule_t [${nr_clusters-1}:0] NoC_SAM;
+  % for i in range(nr_clusters):
+  <% 
+    x = i // x_num + 1
+    y = i % x_num
+  %>
+  assign NoC_SAM[${i}] = '{idx: '{x: ${x}, y: ${y}, port_id: 0}, start_addr: cluster_base_addr[${i}], end_addr:cluster_base_addr[${i}] + ClusterAddressSpace};
+  %endfor
+
+  ///Default ID
+  floo_${noc_name}_noc_pkg::id_t DEFAULT_ID = '{x: 0, y: 0, port_id: 0};
+
+  floo_${noc_name}_noc_pkg::axi_noc_narrow_out_req_t  [${x_num}:0][${y_num-1}:0] cluster_noc_narrow_out_req;
+  floo_${noc_name}_noc_pkg::axi_noc_narrow_out_rsp_t  [${x_num}:0][${y_num-1}:0] cluster_noc_narrow_out_rsp;
+  floo_${noc_name}_noc_pkg::axi_noc_wide_out_req_t    [${x_num}:0][${y_num-1}:0] cluster_noc_wide_out_req;
+  floo_${noc_name}_noc_pkg::axi_noc_wide_out_rsp_t    [${x_num}:0][${y_num-1}:0] cluster_noc_wide_out_rsp;
+  floo_${noc_name}_noc_pkg::axi_noc_narrow_in_req_t [${x_num}:0][${y_num-1}:0] cluster_noc_narrow_in_req;
+  floo_${noc_name}_noc_pkg::axi_noc_narrow_in_rsp_t [${x_num}:0][${y_num-1}:0] cluster_noc_narrow_in_rsp;
+  floo_${noc_name}_noc_pkg::axi_noc_wide_in_req_t   [${x_num}:0][${y_num-1}:0] cluster_noc_wide_in_req;
+  floo_${noc_name}_noc_pkg::axi_noc_wide_in_rsp_t   [${x_num}:0][${y_num-1}:0] cluster_noc_wide_in_rsp;
+
+
+  floo_${noc_name}_noc i_floonoc(
+    .clk_i                       (clk_quadrant_uncore        ),
+    .rst_ni                      (rst_quadrant_n             ),
+    .test_enable_i               (test_mode_i                ),
+    .Sam_i                       (NoC_SAM                    ),
+    .en_default_idx_i            (1'b1                       ),
+    .default_idx_i               (DEFAULT_ID                 ),
+    .cluster_noc_narrow_in_req_i (cluster_noc_narrow_in_req  ),
+    .cluster_noc_narrow_in_rsp_o (cluster_noc_narrow_in_rsp  ),
+    .cluster_noc_wide_in_req_i   (cluster_noc_wide_in_req    ),
+    .cluster_noc_wide_in_rsp_o   (cluster_noc_wide_in_rsp    ),
+    .cluster_noc_narrow_out_req_o(cluster_noc_narrow_out_req ),
+    .cluster_noc_narrow_out_rsp_i(cluster_noc_narrow_out_rsp ),
+    .cluster_noc_wide_out_req_o  (cluster_noc_wide_out_req   ),
+    .cluster_noc_wide_out_rsp_i  (cluster_noc_wide_out_rsp   )
+  );
+  // Tied the unused inputs
+  % for j in range(1,y_num):
+  assign cluster_noc_narrow_in_req[0][${j}] = '0;
+  assign cluster_noc_wide_in_req[0][${j}] = '0;
+  assign cluster_noc_narrow_out_rsp[0][${j}] = '0;
+  assign cluster_noc_wide_out_rsp[0][${j}] = '0;
+  % endfor
+
+%else:
   ///////////////////
   //   CROSSBARS   //
   ///////////////////
   ${module}
-
+%endif
   ///////////////////////////////
   // Narrow In + IW Converter //
   ///////////////////////////////
+  %if en_floonoc:
+  <%
+    narrow_cluster_in_ctrl = soc_narrow_xbar.out_s1_quadrant_0 \
+      .copy(name="narrow_cluster_in_ctrl") \
+      .declare(context)
+    narrow_cluster_in_ctrl \
+      .cut(context, cuts_narrx_with_ctrl) \
+      .isolate(context, "isolate[0]", "narrow_cluster_in_isolate", isolated="isolated[0]", terminated=True, to_clk="clk_quadrant_uncore", to_rst="rst_quadrant_n", num_pending=narrow_trans) \
+      .change_iw(context, occamy_cfg["s1_quadrant"]["narrow_xbar_slv_id_width"], "narrow_cluster_in_iwc")
+  %>
+  assign cluster_noc_narrow_in_req[0][0] = narrow_cluster_in_iwc_req;
+  assign narrow_cluster_in_iwc_rsp = cluster_noc_narrow_in_rsp[0][0];
+  %else:
   <%
     narrow_cluster_in_ctrl = soc_narrow_xbar.out_s1_quadrant_0 \
       .copy(name="narrow_cluster_in_ctrl") \
@@ -98,10 +174,150 @@ module ${name}_quadrant_s1
       .isolate(context, "isolate[0]", "narrow_cluster_in_isolate", isolated="isolated[0]", terminated=True, to_clk="clk_quadrant_uncore", to_rst="rst_quadrant_n", num_pending=narrow_trans) \
       .change_iw(context, narrow_xbar_quadrant_s1.in_top.iw, "narrow_cluster_in_iwc", to=narrow_xbar_quadrant_s1.in_top)
   %>
+  %endif
 
   /////////////////////////////////////
   // Narrow Out + TLB + IW Converter //
   /////////////////////////////////////
+
+  %if en_floonoc:
+  // We do not have the solder for noc
+  // So we do it manually for now
+
+  floo_${noc_name}_noc_pkg::axi_noc_narrow_out_req_t narrow_cluster_out_tlb_req;
+  floo_${noc_name}_noc_pkg::axi_noc_narrow_out_rsp_t narrow_cluster_out_tlb_rsp;
+
+  %if narrow_tlb_cfg:
+  axi_tlb_noreg #(
+    .AxiSlvPortAddrWidth(48),
+    .AxiMstPortAddrWidth(48),
+    .AxiDataWidth(64),
+    .AxiIdWidth(${occamy_cfg["s1_quadrant"]["narrow_xbar_slv_id_width"]}),
+    .AxiUserWidth (${occamy_cfg["s1_quadrant"]["narrow_xbar_slv_user_width"]}),
+    .AxiSlvPortMaxTxns(${occamy_cfg["s1_quadrant"]["narrow_tlb_cfg"]["max_trans"]}),
+    .L1NumEntries(${occamy_cfg["s1_quadrant"]["narrow_tlb_cfg"]["l1_num_entries"]}),
+    .L1CutAx(${"1'b1" if occamy_cfg["s1_quadrant"]["narrow_tlb_cfg"]["l1_cut_ax"] else "1'b0"}),
+    .slv_req_t(floo_${noc_name}_noc_pkg::axi_noc_narrow_out_req_t),
+    .mst_req_t(floo_${noc_name}_noc_pkg::axi_noc_narrow_out_req_t),
+    .axi_resp_t(floo_${noc_name}_noc_pkg::axi_noc_narrow_out_rsp_t),
+    .entry_t(tlb_entry_t)
+  ) i_narrow_cluster_out_tlb (
+    .clk_i (clk_quadrant),
+    .rst_ni (rst_quadrant_n),
+    .test_en_i(test_mode_i),
+    .slv_req_i (cluster_noc_narrow_out_req[0][0]),
+    .slv_resp_o (cluster_noc_narrow_out_rsp[0][0]),
+    .mst_req_o (narrow_cluster_out_tlb_req),
+    .mst_resp_i (narrow_cluster_out_tlb_rsp),
+    .entries_i (narrow_tlb_entries),
+    .bypass_i (~narrow_tlb_enable)
+  );
+  %else:
+  assign narrow_cluster_out_tlb_req = cluster_noc_narrow_out_req[0][0];
+  assign cluster_noc_narrow_out_rsp[0][0] = narrow_cluster_out_tlb_rsp;
+  %endif
+  <%
+    quad_narrow_out_id_width = cluster_cfgs[0]["id_width_in"]
+    quad_narrow_out_user_width = cluster_cfgs[0]["user_width"]
+    soc_narrow_out_id_width = soc_narrow_xbar.in_s1_quadrant_0.iw
+    soc_narrow_out_user_width = soc_narrow_xbar.in_s1_quadrant_0.uw
+  %>
+  
+  ${soc_narrow_xbar.in_s1_quadrant_0.req_type()} narrow_cluster_out_iwc_req;
+  ${soc_narrow_xbar.in_s1_quadrant_0.rsp_type()} narrow_cluster_out_iwc_rsp;
+  typedef logic [${soc_narrow_xbar.iw-quad_narrow_out_id_width-1}:0] narrow_cluster_out_iwc_pre_id_t;
+
+  axi_id_prepend #(
+    .slv_aw_chan_t  ( floo_${noc_name}_noc_pkg::axi_noc_narrow_out_aw_chan_t ),
+    .slv_w_chan_t   ( floo_${noc_name}_noc_pkg::axi_noc_narrow_out_w_chan_t ),
+    .slv_b_chan_t   ( floo_${noc_name}_noc_pkg::axi_noc_narrow_out_b_chan_t ),
+    .slv_ar_chan_t  ( floo_${noc_name}_noc_pkg::axi_noc_narrow_out_ar_chan_t ),
+    .slv_r_chan_t   ( floo_${noc_name}_noc_pkg::axi_noc_narrow_out_r_chan_t ),
+    .mst_aw_chan_t  ( ${soc_narrow_xbar.in_s1_quadrant_0.aw_chan_type()} ),
+    .mst_w_chan_t   ( ${soc_narrow_xbar.in_s1_quadrant_0.w_chan_type()} ),
+    .mst_b_chan_t   ( ${soc_narrow_xbar.in_s1_quadrant_0.b_chan_type()} ),
+    .mst_ar_chan_t  ( ${soc_narrow_xbar.in_s1_quadrant_0.ar_chan_type()} ),
+    .mst_r_chan_t   ( ${soc_narrow_xbar.in_s1_quadrant_0.r_chan_type()} ),
+    .NoBus          ( 1 ),
+    .AxiIdWidthSlvPort ( ${quad_narrow_out_id_width} ),
+    .AxiIdWidthMstPort ( ${soc_narrow_out_id_width} )
+  ) i_narrow_cluster_out_iwc (
+    .pre_id_i           (narrow_cluster_out_iwc_pre_id_t'(0)),
+    .slv_aw_chans_i     (narrow_cluster_out_tlb_req.aw),
+    .slv_aw_valids_i    (narrow_cluster_out_tlb_req.aw_valid),
+    .slv_aw_readies_o   (narrow_cluster_out_tlb_rsp.aw_ready),
+    .slv_w_chans_i      (narrow_cluster_out_tlb_req.w),
+    .slv_w_valids_i     (narrow_cluster_out_tlb_req.w_valid),
+    .slv_w_readies_o    (narrow_cluster_out_tlb_rsp.w_ready),
+    .slv_b_chans_o      (narrow_cluster_out_tlb_rsp.b),
+    .slv_b_valids_o     (narrow_cluster_out_tlb_rsp.b_valid),
+    .slv_b_readies_i    (narrow_cluster_out_tlb_req.b_ready),
+    .slv_ar_chans_i     (narrow_cluster_out_tlb_req.ar),
+    .slv_ar_valids_i    (narrow_cluster_out_tlb_req.ar_valid),
+    .slv_ar_readies_o   (narrow_cluster_out_tlb_rsp.ar_ready),
+    .slv_r_chans_o      (narrow_cluster_out_tlb_rsp.r),
+    .slv_r_valids_o     (narrow_cluster_out_tlb_rsp.r_valid),
+    .slv_r_readies_i    (narrow_cluster_out_tlb_req.r_ready),
+    .mst_aw_chans_o     (narrow_cluster_out_iwc_req.aw),
+    .mst_aw_valids_o    (narrow_cluster_out_iwc_req.aw_valid),
+    .mst_aw_readies_i   (narrow_cluster_out_iwc_rsp.aw_ready),
+    .mst_w_chans_o      (narrow_cluster_out_iwc_req.w),
+    .mst_w_valids_o     (narrow_cluster_out_iwc_req.w_valid),
+    .mst_w_readies_i    (narrow_cluster_out_iwc_rsp.w_ready),
+    .mst_b_chans_i      (narrow_cluster_out_iwc_rsp.b),
+    .mst_b_valids_i     (narrow_cluster_out_iwc_rsp.b_valid),
+    .mst_b_readies_o    (narrow_cluster_out_iwc_req.b_ready),
+    .mst_ar_chans_o     (narrow_cluster_out_iwc_req.ar),
+    .mst_ar_valids_o    (narrow_cluster_out_iwc_req.ar_valid),
+    .mst_ar_readies_i   (narrow_cluster_out_iwc_rsp.ar_ready),
+    .mst_r_chans_i      (narrow_cluster_out_iwc_rsp.r),
+    .mst_r_valids_i     (narrow_cluster_out_iwc_rsp.r_valid),
+    .mst_r_readies_o    (narrow_cluster_out_iwc_req.r_ready)
+  );
+
+  ${soc_narrow_xbar.in_s1_quadrant_0.req_type()} narrow_cluster_out_isolate_req;
+  ${soc_narrow_xbar.in_s1_quadrant_0.rsp_type()} narrow_cluster_out_isolate_rsp;
+  axi_isolate #(
+    .NumPending   ( ${narrow_trans} ),
+    .TerminateTransaction ( 0 ),
+    .AtopSupport  ( 1 ),
+    .AxiIdWidth   ( ${soc_narrow_out_id_width} ),
+    .AxiAddrWidth ( 48 ),
+    .AxiDataWidth ( 64 ),
+    .AxiUserWidth ( ${soc_narrow_out_user_width} ),
+    .axi_req_t    ( ${soc_narrow_xbar.in_s1_quadrant_0.req_type()} ),
+    .axi_resp_t   ( ${soc_narrow_xbar.in_s1_quadrant_0.rsp_type()} )
+  ) i_narrow_cluster_out_isolate (
+    .clk_i      ( clk_i ),
+    .rst_ni     ( rst_ni ),
+    .slv_req_i  ( narrow_cluster_out_iwc_req ),
+    .slv_resp_o ( narrow_cluster_out_iwc_rsp ),
+    .mst_req_o  ( narrow_cluster_out_isolate_req ),
+    .mst_resp_i ( narrow_cluster_out_isolate_rsp ),
+    .isolate_i  ( isolate[1] ),
+    .isolated_o ( isolated[1] )
+  );
+
+  ${soc_narrow_xbar.in_s1_quadrant_0.req_type()} narrow_cluster_out_ctrl_req;
+  ${soc_narrow_xbar.in_s1_quadrant_0.rsp_type()} narrow_cluster_out_ctrl_rsp;
+  axi_multicut #(
+    .NoCuts     ( ${cuts_narrx_with_ctrl}),
+    .aw_chan_t  ( ${soc_narrow_xbar.in_s1_quadrant_0.aw_chan_type()}),
+    .w_chan_t   ( ${soc_narrow_xbar.in_s1_quadrant_0.w_chan_type()}),
+    .b_chan_t   ( ${soc_narrow_xbar.in_s1_quadrant_0.b_chan_type()}),
+    .ar_chan_t  ( ${soc_narrow_xbar.in_s1_quadrant_0.ar_chan_type()}),
+    .r_chan_t   ( ${soc_narrow_xbar.in_s1_quadrant_0.r_chan_type()}),
+    .axi_req_t  ( ${soc_narrow_xbar.in_s1_quadrant_0.req_type()}),
+    .axi_resp_t ( ${soc_narrow_xbar.in_s1_quadrant_0.rsp_type()})
+  ) i_narrow_cluster_out_ctrl (
+    .clk_i      (clk_i),
+    .rst_ni     (rst_ni),
+    .slv_req_i  (narrow_cluster_out_isolate_req),
+    .slv_resp_o (narrow_cluster_out_isolate_rsp),
+    .mst_req_o  (narrow_cluster_out_ctrl_req),
+    .mst_resp_i (narrow_cluster_out_ctrl_rsp)
+  );  
+  %else:
   <%
   #// Add TLB behind crossbar if enabled
   if narrow_tlb_cfg:
@@ -118,13 +334,216 @@ module ${name}_quadrant_s1
     .change_iw(context, soc_narrow_xbar.in_s1_quadrant_0.iw, "narrow_cluster_out_iwc") \
     .isolate(context, "isolate[1]", "narrow_cluster_out_isolate", isolated="isolated[1]", to_clk="clk_i", to_rst="rst_ni", use_to_clk_rst=True, num_pending=narrow_trans) \
     .cut(context, cuts_narrx_with_ctrl, "narrow_cluster_out_ctrl")
-   %>
-
+  %>
+  %endif
   /////////////////////////////////////////
   // Wide Out + RO Cache + IW Converter  //
   /////////////////////////////////////////
+  %if en_floonoc:
+  floo_${noc_name}_noc_pkg::axi_noc_wide_out_req_t quad_wide_out_tlb_req;
+  floo_${noc_name}_noc_pkg::axi_noc_wide_out_rsp_t quad_wide_out_tlb_rsp;
+  %if wide_tlb_cfg:
+  axi_tlb_noreg #(
+    .AxiSlvPortAddrWidth(48),
+    .AxiMstPortAddrWidth(48),
+    .AxiDataWidth(512),
+    .AxiIdWidth(${occamy_cfg["s1_quadrant"]["wide_xbar_slv_id_width"]}),
+    .AxiUserWidth (${occamy_cfg["s1_quadrant"]["wide_xbar_slv_user_width"]}),
+    .AxiSlvPortMaxTxns(${occamy_cfg["s1_quadrant"]["wide_tlb_cfg"]["max_trans"]}),
+    .L1NumEntries(${occamy_cfg["s1_quadrant"]["wide_tlb_cfg"]["l1_num_entries"]}),
+    .L1CutAx(${"1'b1" if occamy_cfg["s1_quadrant"]["wide_tlb_cfg"]["l1_cut_ax"] else "1'b0"}),
+    .slv_req_t(floo_${noc_name}_noc_pkg::axi_noc_wide_in_req_t),
+    .mst_req_t(floo_${noc_name}_noc_pkg::axi_noc_wide_in_req_t),
+    .axi_resp_t(floo_${noc_name}_noc_pkg::axi_noc_wide_in_rsp_t),
+    .entry_t(tlb_entry_t)
+  ) i_wide_cluster_out_tlb (
+    .clk_i (clk_quadrant_uncore),
+    .rst_ni (rst_quadrant_n),
+    .test_en_i(test_mode_i),
+    .slv_req_i (cluster_noc_wide_out_req[0][0]),
+    .slv_resp_o (cluster_noc_wide_out_rsp[0][0]),
+    .mst_req_o (quad_wide_out_tlb_req),
+    .mst_resp_i (quad_wide_out_tlb_rsp),
+    .entries_i (wide_tlb_entries),
+    .bypass_i (~wide_tlb_enable)
+  );
+  %else:
+
+  assign quad_wide_out_tlb_req = cluster_noc_wide_out_req[0][0];
+  assign cluster_noc_wide_out_rsp[0][0] = quad_wide_out_tlb_rsp;
+  %endif
+
   <%
-    wide_target_iw = 3
+    ro_cache_id_width = cluster_cfgs[0]["dma_id_width_in"] + 1
+    ro_cache_user_width = cluster_cfgs[0]["dma_user_width"]
+  %>
+  `AXI_TYPEDEF_ALL_CT(axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width},
+                      axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_req_t,
+                      axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_resp_t,
+                      logic [47:0],
+                      logic [${ro_cache_id_width-1}:0],
+                      logic [511:0],
+                      logic [63:0],
+                      logic [${ro_cache_user_width-1}:0])
+
+  axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_req_t snitch_ro_cache_req;
+  axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_resp_t snitch_ro_cache_rsp;
+  snitch_read_only_cache #(
+      .LineWidth    (${occamy_cfg["s1_quadrant"]["ro_cache_cfg"]["width"]}),
+      .LineCount    (${occamy_cfg["s1_quadrant"]["ro_cache_cfg"]["count"]}),
+      .WayCount     (${occamy_cfg["s1_quadrant"]["ro_cache_cfg"]["sets"]}),
+      .AxiAddrWidth (48),
+      .AxiDataWidth (512),
+      .AxiIdWidth   (${cluster_cfgs[0]["dma_id_width_in"]}),
+      .AxiUserWidth (${cluster_cfgs[0]["dma_user_width"]}),
+      .MaxTrans     (${occamy_cfg["s1_quadrant"]["ro_cache_cfg"]["max_trans"]}),
+      .NrAddrRules  (${occamy_cfg["s1_quadrant"]["ro_cache_cfg"]["address_regions"]}),
+      .slv_req_t    (floo_${noc_name}_noc_pkg::axi_noc_wide_out_req_t),
+      .slv_rsp_t    (floo_${noc_name}_noc_pkg::axi_noc_wide_out_rsp_t),
+      .mst_req_t    (axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_req_t),
+      .mst_rsp_t    (axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_resp_t),
+      .sram_cfg_data_t (sram_cfg_t),
+      .sram_cfg_tag_t (sram_cfg_t)
+    ) i_snitch_ro_cache (
+      .clk_i (clk_quadrant_uncore),
+      .rst_ni (rst_quadrant_n),
+      .enable_i (ro_enable),
+      .flush_valid_i (ro_flush_valid),
+      .flush_ready_o (ro_flush_ready),
+      .start_addr_i (ro_start_addr),
+      .end_addr_i (ro_end_addr),
+      .axi_slv_req_i (quad_wide_out_tlb_req),
+      .axi_slv_rsp_o (quad_wide_out_tlb_rsp),
+      .axi_mst_req_o (snitch_ro_cache_req),
+      .axi_mst_rsp_i (snitch_ro_cache_rsp),
+      .sram_cfg_data_i (sram_cfg_i.rocache_data),
+      .sram_cfg_tag_i (sram_cfg_i.rocache_tag)
+    );
+
+  axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_req_t snitch_ro_cache_cut_req;
+  axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_resp_t snitch_ro_cache_cut_rsp;
+  axi_multicut #(
+    .NoCuts (1),
+    .aw_chan_t  (axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_aw_chan_t),
+    .w_chan_t   (axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_w_chan_t),
+    .b_chan_t   (axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_b_chan_t),
+    .ar_chan_t  (axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_ar_chan_t),
+    .r_chan_t   (axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_r_chan_t),
+    .axi_req_t  (axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_req_t),
+    .axi_resp_t (axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_resp_t)
+  ) i_snitch_ro_cache_cut (
+    .clk_i (clk_quadrant_uncore),
+    .rst_ni (rst_quadrant_n),
+    .slv_req_i (snitch_ro_cache_req),
+    .slv_resp_o (snitch_ro_cache_rsp),
+    .mst_req_o (snitch_ro_cache_cut_req),
+    .mst_resp_i (snitch_ro_cache_cut_rsp)
+  );
+
+  ${soc_wide_xbar.in_quadrant_0.req_type()} wide_cluster_out_iwc_req;
+  ${soc_wide_xbar.in_quadrant_0.rsp_type()} wide_cluster_out_iwc_rsp;
+  typedef logic [${soc_wide_xbar.in_quadrant_0.iw-ro_cache_id_width-1}:0] wide_cluster_out_iwc_pre_id_t;
+  axi_id_prepend #(
+    .slv_aw_chan_t  ( axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_aw_chan_t ),
+    .slv_w_chan_t   ( axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_w_chan_t ),
+    .slv_b_chan_t   ( axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_b_chan_t ),
+    .slv_ar_chan_t  ( axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_ar_chan_t ),
+    .slv_r_chan_t   ( axi_a48_d512_i${ro_cache_id_width}_u${ro_cache_user_width}_r_chan_t ),
+    .mst_aw_chan_t  ( ${soc_wide_xbar.in_quadrant_0.aw_chan_type()} ),
+    .mst_w_chan_t   ( ${soc_wide_xbar.in_quadrant_0.w_chan_type()} ),
+    .mst_b_chan_t   ( ${soc_wide_xbar.in_quadrant_0.b_chan_type()} ),
+    .mst_ar_chan_t  ( ${soc_wide_xbar.in_quadrant_0.ar_chan_type()} ),
+    .mst_r_chan_t   ( ${soc_wide_xbar.in_quadrant_0.r_chan_type()} ),
+    .NoBus          ( 1 ),
+    .AxiIdWidthSlvPort ( ${ro_cache_id_width} ),
+    .AxiIdWidthMstPort ( ${soc_wide_xbar.in_quadrant_0.iw} )
+  ) i_wide_cluster_out_iwc (
+    .pre_id_i           (wide_cluster_out_iwc_pre_id_t'(0)),
+    .slv_aw_chans_i     (snitch_ro_cache_cut_req.aw),
+    .slv_aw_valids_i    (snitch_ro_cache_cut_req.aw_valid),
+    .slv_aw_readies_o   (snitch_ro_cache_cut_rsp.aw_ready),
+    .slv_w_chans_i      (snitch_ro_cache_cut_req.w),
+    .slv_w_valids_i     (snitch_ro_cache_cut_req.w_valid),
+    .slv_w_readies_o    (snitch_ro_cache_cut_rsp.w_ready),
+    .slv_b_chans_o      (snitch_ro_cache_cut_rsp.b),
+    .slv_b_valids_o     (snitch_ro_cache_cut_rsp.b_valid),
+    .slv_b_readies_i    (snitch_ro_cache_cut_req.b_ready),
+    .slv_ar_chans_i     (snitch_ro_cache_cut_req.ar),
+    .slv_ar_valids_i    (snitch_ro_cache_cut_req.ar_valid),
+    .slv_ar_readies_o   (snitch_ro_cache_cut_rsp.ar_ready),
+    .slv_r_chans_o      (snitch_ro_cache_cut_rsp.r),
+    .slv_r_valids_o     (snitch_ro_cache_cut_rsp.r_valid),
+    .slv_r_readies_i    (snitch_ro_cache_cut_req.r_ready),
+    .mst_aw_chans_o     (wide_cluster_out_iwc_req.aw),
+    .mst_aw_valids_o    (wide_cluster_out_iwc_req.aw_valid),
+    .mst_aw_readies_i   (wide_cluster_out_iwc_rsp.aw_ready),
+    .mst_w_chans_o      (wide_cluster_out_iwc_req.w),
+    .mst_w_valids_o     (wide_cluster_out_iwc_req.w_valid),
+    .mst_w_readies_i    (wide_cluster_out_iwc_rsp.w_ready),
+    .mst_b_chans_i      (wide_cluster_out_iwc_rsp.b),
+    .mst_b_valids_i     (wide_cluster_out_iwc_rsp.b_valid),
+    .mst_b_readies_o    (wide_cluster_out_iwc_req.b_ready),
+    .mst_ar_chans_o     (wide_cluster_out_iwc_req.ar),
+    .mst_ar_valids_o    (wide_cluster_out_iwc_req.ar_valid),
+    .mst_ar_readies_i   (wide_cluster_out_iwc_rsp.ar_ready),
+    .mst_r_chans_i      (wide_cluster_out_iwc_rsp.r),
+    .mst_r_valids_i     (wide_cluster_out_iwc_rsp.r_valid),
+    .mst_r_readies_o    (wide_cluster_out_iwc_req.r_ready)
+  );
+
+
+
+  ${soc_wide_xbar.in_quadrant_0.req_type()} wide_cluster_out_isolate_req;
+  ${soc_wide_xbar.in_quadrant_0.rsp_type()} wide_cluster_out_isolate_rsp;
+
+  axi_isolate #(
+    .NumPending ( 32 ),
+    .TerminateTransaction ( 0 ),
+    .AtopSupport ( 0 ),
+    .AxiIdWidth ( ${soc_wide_xbar.iw} ),
+    .AxiAddrWidth ( 48 ),
+    .AxiDataWidth ( 512 ),
+    .AxiUserWidth ( ${soc_wide_xbar.uw} ),
+    .axi_req_t ( ${soc_wide_xbar.in_quadrant_0.req_type()} ),
+    .axi_resp_t ( ${soc_wide_xbar.in_quadrant_0.rsp_type()} )
+  ) i_wide_cluster_out_isolate (
+    .clk_i      ( clk_i                        ),
+    .rst_ni     ( rst_ni                       ),
+    .slv_req_i  ( wide_cluster_out_iwc_req     ),
+    .slv_resp_o ( wide_cluster_out_iwc_rsp     ),
+    .mst_req_o  ( wide_cluster_out_isolate_req ),
+    .mst_resp_i ( wide_cluster_out_isolate_rsp ),
+    .isolate_i  ( isolate[3]                   ),
+    .isolated_o ( isolated[3]                  )
+  );
+
+  ${soc_wide_xbar.in_quadrant_0.req_type()} wide_cluster_out_isolate_cut_req;
+  ${soc_wide_xbar.in_quadrant_0.rsp_type()} wide_cluster_out_isolate_cut_rsp;
+
+  axi_multicut #(
+    .NoCuts (1),
+    .aw_chan_t (${soc_wide_xbar.in_quadrant_0.aw_chan_type()}),
+    .w_chan_t (${soc_wide_xbar.in_quadrant_0.w_chan_type()}),
+    .b_chan_t (${soc_wide_xbar.in_quadrant_0.b_chan_type()}),
+    .ar_chan_t (${soc_wide_xbar.in_quadrant_0.ar_chan_type()}),
+    .r_chan_t (${soc_wide_xbar.in_quadrant_0.r_chan_type()}),
+    .axi_req_t (${soc_wide_xbar.in_quadrant_0.req_type()}),
+    .axi_resp_t (${soc_wide_xbar.in_quadrant_0.rsp_type()})
+  ) i_wide_cluster_out_isolate_cut (
+    .clk_i (clk_i),
+    .rst_ni (rst_ni),
+    .slv_req_i (wide_cluster_out_isolate_req),
+    .slv_resp_o (wide_cluster_out_isolate_rsp),
+    .mst_req_o (wide_cluster_out_isolate_cut_req),
+    .mst_resp_i (wide_cluster_out_isolate_cut_rsp)
+  );
+  assign quadrant_wide_out_req_o = wide_cluster_out_isolate_cut_req;
+  assign wide_cluster_out_isolate_cut_rsp = quadrant_wide_out_rsp_i;
+
+
+  %else:
+  <%
+    wide_target_iw = occamy_cfg["s1_quadrant"]["wide_xbar_slv_id_width"]
     #// Add TLB behind crossbar if enabled
     if wide_tlb_cfg:
       wide_cluster_out_tlb = wide_xbar_quadrant_s1.out_top \
@@ -160,15 +579,33 @@ module ${name}_quadrant_s1
       .isolate(context, "isolate[3]", "wide_cluster_out_isolate", isolated="isolated[3]", atop_support=False, to_clk="clk_i", to_rst="rst_ni", use_to_clk_rst=True, num_pending=wide_trans) \
       .cut(context, cuts_wideiwc_with_wideout)
     #// Assert correct outgoing ID widths
-    assert soc_wide_xbar.in_quadrant_0.iw == wide_cluster_out_cut.iw, "S1 Quadrant and SoC IW mismatches."
+    assert soc_wide_xbar.in_quadrant_0.iw == wide_cluster_out_cut.iw, f"Wide IW for S1 Quadrant and SoC mismatches. SOC IW={soc_wide_xbar.in_quadrant_0.iw}, Quadrant IW={wide_cluster_out_cut.iw}"
   %>
 
   assign quadrant_wide_out_req_o = ${wide_cluster_out_cut.req_name()};
   assign ${wide_cluster_out_cut.rsp_name()} = quadrant_wide_out_rsp_i;
-
+  %endif
   ////////////////////////////
   // Wide In + IW Converter //
   ////////////////////////////
+  %if en_floonoc:
+  <%
+    soc_wide_xbar.out_quadrant_0 \
+      .copy(name="wide_cluster_in") \
+      .declare(context) \
+      .cut(context, cuts_wideiwc_with_wideout) \
+      .isolate(context, "isolate[2]", "wide_cluster_in_isolate", isolated="isolated[2]", terminated=True, atop_support=False, to_clk="clk_quadrant_uncore", to_rst="rst_quadrant_n", num_pending=wide_trans) \
+      .cut(context, cuts_wideisolate_with_wideiwc_in) \
+      .change_iw(context,  occamy_cfg["s1_quadrant"]["wide_xbar_slv_id_width"],"wide_cluster_in_iwc")
+  %>
+  // to SOC
+  assign wide_cluster_in_req = quadrant_wide_in_req_i;
+  assign quadrant_wide_in_rsp_o = wide_cluster_in_rsp;
+
+  // to Quad NoC
+  assign cluster_noc_wide_in_req[0][0] = wide_cluster_in_iwc_req;
+  assign wide_cluster_in_iwc_rsp = cluster_noc_wide_in_rsp[0][0];
+  %else:
   <%
     soc_wide_xbar.out_quadrant_0 \
       .copy(name="wide_cluster_in_iwc") \
@@ -180,6 +617,8 @@ module ${name}_quadrant_s1
   %>
   assign wide_cluster_in_iwc_req = quadrant_wide_in_req_i;
   assign quadrant_wide_in_rsp_o = wide_cluster_in_iwc_rsp;
+  %endif
+
 
   /////////////////////////
   // Quadrant Controller //
@@ -214,16 +653,53 @@ module ${name}_quadrant_s1
     .wide_tlb_entries_o (wide_tlb_entries),
     .wide_tlb_enable_o (wide_tlb_enable),
     %endif
+    %if en_floonoc:
+    .quadrant_out_req_o (narrow_cluster_in_ctrl_req),
+    .quadrant_out_rsp_i (narrow_cluster_in_ctrl_rsp),
+    .quadrant_in_req_i  (narrow_cluster_out_ctrl_req),
+    .quadrant_in_rsp_o  (narrow_cluster_out_ctrl_rsp)
+    %else:    
     .quadrant_out_req_o (${narrow_cluster_in_ctrl.req_name()}),
     .quadrant_out_rsp_i (${narrow_cluster_in_ctrl.rsp_name()}),
     .quadrant_in_req_i (${narrow_cluster_out_ctrl.req_name()}),
     .quadrant_in_rsp_o (${narrow_cluster_out_ctrl.rsp_name()})
+    %endif 
   );
 
+
 % for i in range(nr_clusters):
+    <% 
+    x = i // x_num
+    y = i % x_num
+    cluster_name = cluster_cfgs[i]["name"]
+    %>
   ///////////////
   // Cluster ${i} //
   ///////////////
+  logic [9:0] hart_base_id_${i};
+  assign hart_base_id_${i} = HartIdOffset + NrCoresClusterOffset[${i}];
+  %if en_floonoc:
+  ${cluster_name}_wrapper i_${name}_cluster_${i} (
+    .clk_i               (clk_quadrant_cluster[${i}]),
+    .rst_ni              (rst_quadrant_n),
+    .meip_i              (meip_i[NrCoresClusterOffset[${i}]+:NrCoresCluster[${i}]]),
+    .mtip_i              (mtip_i[NrCoresClusterOffset[${i}]+:NrCoresCluster[${i}]]),
+    .msip_i              (msip_i[NrCoresClusterOffset[${i}]+:NrCoresCluster[${i}]]),
+    .hart_base_id_i      (hart_base_id_${i}),
+    .cluster_base_addr_i (cluster_base_addr[${i}]),
+    .boot_addr_i         (boot_addr_i), 
+    .narrow_in_req_i     (cluster_noc_narrow_out_req[${x+1}][${y}]),
+    .narrow_in_resp_o    (cluster_noc_narrow_out_rsp[${x+1}][${y}]),
+    .narrow_out_req_o    (cluster_noc_narrow_in_req[${x+1}][${y}]),
+    .narrow_out_resp_i   (cluster_noc_narrow_in_rsp[${x+1}][${y}]),
+    .wide_out_req_o      (cluster_noc_wide_in_req[${x+1}][${y}]),
+    .wide_out_resp_i     (cluster_noc_wide_in_rsp[${x+1}][${y}]),
+    .wide_in_req_i       (cluster_noc_wide_out_req[${x+1}][${y}]),
+    .wide_in_resp_o      (cluster_noc_wide_out_rsp[${x+1}][${y}]),
+    .sram_cfgs_i         (sram_cfg_i.cluster)
+  );
+  %else:
+
   <%
     narrow_cluster_in = narrow_xbar_quadrant_s1.__dict__["out_cluster_{}".format(i)].change_iw(context, cluster_cfgs[i]["id_width_in"], "narrow_in_iwc_{}".format(i)).cut(context, cuts_narrx_with_cluster)
     narrow_cluster_out = narrow_xbar_quadrant_s1.__dict__["in_cluster_{}".format(i)].copy(name="narrow_out_{}".format(i)).declare(context)
@@ -231,31 +707,28 @@ module ${name}_quadrant_s1
     wide_cluster_in = wide_xbar_quadrant_s1.__dict__["out_cluster_{}".format(i)].change_iw(context, cluster_cfgs[i]["dma_id_width_in"], "wide_in_iwc_{}".format(i), max_txns_per_id=wide_trans).cut(context, cuts_widex_with_cluster)
     wide_cluster_out = wide_xbar_quadrant_s1.__dict__["in_cluster_{}".format(i)].copy(name="wide_out_{}".format(i)).declare(context)
     wide_cluster_out.cut(context, cuts_widex_with_cluster, to=wide_xbar_quadrant_s1.__dict__["in_cluster_{}".format(i)])
-    cluster_name = cluster_cfgs[i]["name"]
   %>
 
-  logic [9:0] hart_base_id_${i};
-  assign hart_base_id_${i} = HartIdOffset + NrCoresClusterOffset[${i}];
-
   ${cluster_name}_wrapper i_${name}_cluster_${i} (
-    .clk_i (clk_quadrant_cluster[${i}]),
-    .rst_ni (rst_quadrant_n),
-    .meip_i (meip_i[NrCoresClusterOffset[${i}]+:NrCoresCluster[${i}]]),
-    .mtip_i (mtip_i[NrCoresClusterOffset[${i}]+:NrCoresCluster[${i}]]),
-    .msip_i (msip_i[NrCoresClusterOffset[${i}]+:NrCoresCluster[${i}]]),
-    .hart_base_id_i (hart_base_id_${i}),
+    .clk_i               (clk_quadrant_cluster[${i}]),
+    .rst_ni              (rst_quadrant_n),
+    .meip_i              (meip_i[NrCoresClusterOffset[${i}]+:NrCoresCluster[${i}]]),
+    .mtip_i              (mtip_i[NrCoresClusterOffset[${i}]+:NrCoresCluster[${i}]]),
+    .msip_i              (msip_i[NrCoresClusterOffset[${i}]+:NrCoresCluster[${i}]]),
+    .hart_base_id_i      (hart_base_id_${i}),
     .cluster_base_addr_i (cluster_base_addr[${i}]),
-    .boot_addr_i (boot_addr_i), 
-    .narrow_in_req_i (${narrow_cluster_in.req_name()}),
-    .narrow_in_resp_o (${narrow_cluster_in.rsp_name()}),
-    .narrow_out_req_o  (${narrow_cluster_out.req_name()}),
-    .narrow_out_resp_i (${narrow_cluster_out.rsp_name()}),
-    .wide_out_req_o  (${wide_cluster_out.req_name()}),
-    .wide_out_resp_i (${wide_cluster_out.rsp_name()}),
-    .wide_in_req_i (${wide_cluster_in.req_name()}),
-    .wide_in_resp_o (${wide_cluster_in.rsp_name()}),
-    .sram_cfgs_i (sram_cfg_i.cluster)
+    .boot_addr_i         (boot_addr_i), 
+    .narrow_in_req_i     (${narrow_cluster_in.req_name()}),
+    .narrow_in_resp_o    (${narrow_cluster_in.rsp_name()}),
+    .narrow_out_req_o    (${narrow_cluster_out.req_name()}),
+    .narrow_out_resp_i   (${narrow_cluster_out.rsp_name()}),
+    .wide_out_req_o      (${wide_cluster_out.req_name()}),
+    .wide_out_resp_i     (${wide_cluster_out.rsp_name()}),
+    .wide_in_req_i       (${wide_cluster_in.req_name()}),
+    .wide_in_resp_o      (${wide_cluster_in.rsp_name()}),
+    .sram_cfgs_i         (sram_cfg_i.cluster)
   );
+  %endif
 
 % endfor
 endmodule

--- a/hw/occamy/quad_noc/quad_noc.yml.tpl
+++ b/hw/occamy/quad_noc/quad_noc.yml.tpl
@@ -5,8 +5,6 @@ name: ${noc_name}
 description: "NW mesh configuration with ${routing_algo} routing for FlooGen"
 network_type: "narrow-wide"
 
-chip_id_width: 8
-
 routing:
   route_algo: ${routing_algo}
   use_id_table: true

--- a/hw/occamy/quad_noc/quad_noc.yml.tpl
+++ b/hw/occamy/quad_noc/quad_noc.yml.tpl
@@ -1,0 +1,74 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: ${noc_name}
+description: "NW mesh configuration with ${routing_algo} routing for FlooGen"
+network_type: "narrow-wide"
+
+chip_id_width: 8
+
+routing:
+  route_algo: ${routing_algo}
+  use_id_table: true
+  en_default_idx: true
+  default_idx: [0, 0]
+
+protocols:
+  - name: "noc_narrow_in"
+    type: "narrow"
+    protocol: "AXI4"
+    data_width: ${narrow_data_width}
+    addr_width: ${narrow_addr_width}
+    id_width: ${narrow_out_id_width}
+    user_width: ${narrow_user_width}
+  - name: "noc_narrow_out"
+    type: "narrow"
+    protocol: "AXI4"
+    data_width: ${narrow_data_width}
+    addr_width: ${narrow_addr_width}
+    id_width: ${narrow_in_id_width}
+    user_width: ${narrow_user_width}
+  - name: "noc_wide_in"
+    type: "wide"
+    protocol: "AXI4"
+    data_width: ${wide_data_width}
+    addr_width: ${wide_addr_width}
+    id_width: ${wide_out_id_width}
+    user_width: ${wide_user_width}
+  - name: "noc_wide_out"
+    type: "wide"
+    protocol: "AXI4"
+    data_width: ${wide_data_width}
+    addr_width: ${wide_addr_width}
+    id_width: ${wide_in_id_width}
+    user_width: ${wide_user_width}
+
+endpoints:
+  - name: "cluster"
+    array: ${noc_array}
+    addr_range:
+      base: ${cluster_base_addr}
+      size: ${cluster_size}
+    mgr_port_protocol:
+      - "noc_narrow_in"
+      - "noc_wide_in"
+    sbr_port_protocol:
+      - "noc_narrow_out"
+      - "noc_wide_out"
+
+routers:
+  - name: "router"
+    array: ${noc_array}
+    degree: 5
+
+connections:
+  - src: "cluster"
+    dst: "router"
+    src_range:
+    - [0, ${noc_array[0]-1}]
+    - [0, ${noc_array[1]-1}]
+    dst_range:
+    - [0, ${noc_array[0]-1}]
+    - [0, ${noc_array[1]-1}]
+    dst_dir: "Eject"
+

--- a/target/rtl/Makefile
+++ b/target/rtl/Makefile
@@ -149,6 +149,7 @@ $(MISC_OCCAMYGEN_TARGETS): .misc_occamygen_targets_group
 		--pkg-sv           $(SOURCE_OCCAMY_DIR)/occamy_pkg.sv.tpl \
 		--quadrant-s1      $(SOURCE_OCCAMY_DIR)/occamy_quadrant_s1.sv.tpl \
 		--quadrant-s1-ctrl $(SOURCE_OCCAMY_DIR)/occamy_quadrant_s1_ctrl.sv.tpl \
+		--quadrant-s1-noc  $(SOURCE_OCCAMY_DIR)/quad_noc/quad_noc.yml.tpl \
 		--xilinx-sv        $(SOURCE_OCCAMY_DIR)/occamy_xilinx.sv.tpl \
 		--cva6-sv          $(SOURCE_OCCAMY_DIR)/occamy_cva6.sv.tpl
 # --dts 			   $(TARGET_DTS_DIR)/occamy.dts
@@ -169,6 +170,7 @@ debug-occamy-gen:
 		--pkg-sv           $(SOURCE_OCCAMY_DIR)/occamy_pkg.sv.tpl \
 		--quadrant-s1      $(SOURCE_OCCAMY_DIR)/occamy_quadrant_s1.sv.tpl \
 		--quadrant-s1-ctrl $(SOURCE_OCCAMY_DIR)/occamy_quadrant_s1_ctrl.sv.tpl \
+		--quadrant-s1-noc  $(SOURCE_OCCAMY_DIR)/quad_noc/quad_noc.yml.tpl \
 		--xilinx-sv        $(SOURCE_OCCAMY_DIR)/occamy_xilinx.sv.tpl \
 		--cva6-sv          $(SOURCE_OCCAMY_DIR)/occamy_cva6.sv.tpl	
 
@@ -182,6 +184,9 @@ debug-quadrant-ctrl-gen:
 
 debug-quadrant-gen:
 	$(OCCAMYGEN) --cfg $(CFG) --outdir $(TARGET_SRC_DIR) --quadrant-s1      $(SOURCE_OCCAMY_DIR)/occamy_quadrant_s1.sv.tpl
+
+debug-quadrant-noc-gen:
+	$(OCCAMYGEN) --cfg $(CFG) --outdir $(TARGET_SRC_DIR) --quadrant-s1-noc  $(SOURCE_OCCAMY_DIR)/quad_noc/quad_noc.yml.tpl
 ############
 # QUADCTRL #
 ############

--- a/target/rtl/cfg/hemaia_noc.hjson
+++ b/target/rtl/cfg/hemaia_noc.hjson
@@ -1,5 +1,5 @@
 {
-    bender_target: ["cv64a6_imafdc_sv39", "occamy"],
+    bender_target: ["cv64a6_imafdc_sv39", "occamy", "occamy_noc"],
     // Remote CFG, about to be removed
     is_remote_quadrant: false,
     remote_quadrants: [],

--- a/target/rtl/cfg/hemaia_noc.hjson
+++ b/target/rtl/cfg/hemaia_noc.hjson
@@ -64,7 +64,7 @@
       // Non-right-side chip peripherals
       periph_axi_lite_narrow_hbm_cfg: 3,
       periph_axi_lite_narrow_pcie_cfg: 3,
-      periph_axi_lite_narrow_chip_ctrl_cfg: 3,
+      periph_axi_lite_narrow_hemaia_clk_rst_controller_cfg: 3,
       periph_axi_lite_narrow_hbi_narrow_cfg: 3,
       periph_axi_lite_narrow_hbi_wide_cfg: 3,
       periph_axi_lite_narrow_bootrom_cfg: 3,
@@ -173,13 +173,18 @@
                 length: 4096, // 4 kiB 0x1000
             },
             {
-                name: "chip_ctrl",
+                name: "hemaia_clk_rst_controller",
                 address: 33574912, // 0x0200_5000
                 length: 4096, // 4 kiB 0x1000
             },
             {
                 name: "timer",
                 address: 33579008, // 0x0200_6000
+                length: 4096, // 4 kiB 0x1000
+            },
+            {
+                name: "hemaia_d2d_link",
+                address: 33583104, // 0x0200_7000
                 length: 4096, // 4 kiB 0x1000
             },
             {

--- a/target/rtl/cfg/hemaia_noc.hjson
+++ b/target/rtl/cfg/hemaia_noc.hjson
@@ -1,0 +1,218 @@
+{
+    bender_target: ["cv64a6_imafdc_sv39", "occamy"],
+    // Remote CFG, about to be removed
+    is_remote_quadrant: false,
+    remote_quadrants: [],
+    // Multi-chip configuration
+    hemaia_multichip: {
+      chip_id_width: 8, 
+      router_to_soc_iw: 8,
+      soc_to_router_iw: 4,
+      single_chip: true,
+      single_chip_id: 0, 
+      testbench_cfg: {
+        // Emulate a four-chips configuration
+        upper_left_coordinate: [0, 0],
+        lower_right_coordinate: [1, 1]
+      }
+    }
+    addr_width: 48,
+    data_width: 64,
+    // XBARs
+    wide_xbar: {
+      max_slv_trans: 64,
+      max_mst_trans: 64,
+      fall_through: false,
+    },
+    quadrant_inter_xbar: {
+      max_slv_trans: 64,
+      max_mst_trans: 64,
+      fall_through: false,
+    },
+    narrow_xbar: {
+      max_slv_trans: 32,
+      max_mst_trans: 32,
+      fall_through: false,
+    },
+    cuts: {
+      soc_to_router: 1,
+      router_to_soc: 1,
+      narrow_to_quad: 3,
+      quad_to_narrow: 3,
+      wide_to_quad: 3,
+      quad_to_wide: 3,
+      narrow_to_cva6: 2,
+      narrow_conv_to_spm_narrow_pre: 2,
+      narrow_conv_to_spm_narrow: 1,
+      narrow_and_pcie: 3,
+      narrow_and_wide: 1,
+      wide_to_hemaia_mem: 1,
+      hemaia_mem_to_wide: 1,
+      wide_to_wide_zero_mem: 0,
+      wide_to_hbm: 3,
+      wide_and_inter: 3,
+      wide_and_hbi: 3,
+      narrow_and_hbi: 3,
+      pre_to_hbmx: 3,
+      hbmx_to_hbm: 3,
+      atomic_adapter_narrow: 1,
+      atomic_adapter_narrow_wide: 1,
+      // Give some flexibility in peripheral xbar placement
+      periph_axi_lite_narrow: 2,
+      periph_axi_lite: 2,
+      periph_axi_lite_narrow_hbm_xbar_cfg: 2,
+      // Non-right-side chip peripherals
+      periph_axi_lite_narrow_hbm_cfg: 3,
+      periph_axi_lite_narrow_pcie_cfg: 3,
+      periph_axi_lite_narrow_chip_ctrl_cfg: 3,
+      periph_axi_lite_narrow_hbi_narrow_cfg: 3,
+      periph_axi_lite_narrow_hbi_wide_cfg: 3,
+      periph_axi_lite_narrow_bootrom_cfg: 3,
+      periph_axi_lite_narrow_fll_system_cfg: 3,
+      periph_axi_lite_narrow_fll_periph_cfg: 3,
+      periph_axi_lite_narrow_fll_hbm2e_cfg: 3,
+      // Right-side or latency-invariant chip peripherals
+      periph_axi_lite_narrow_soc_ctrl_cfg: 1,
+      periph_axi_lite_narrow_uart_cfg: 1,
+      periph_axi_lite_narrow_i2c_cfg: 1,
+      periph_axi_lite_narrow_gpio_cfg: 1,
+      periph_axi_lite_narrow_clint_cfg: 1,
+      periph_axi_lite_narrow_plic_cfg: 1,
+      periph_axi_lite_narrow_spim_cfg: 1,
+      periph_axi_lite_narrow_timer_cfg: 1,
+    },
+    txns: {
+      wide_and_inter: 128,
+      wide_to_hbm: 128,
+      narrow_and_wide: 16,
+      rmq: 4,
+    },
+    nr_s1_quadrant: 1,
+    s1_quadrant: {
+      noc_cfg: {
+        en_floonoc: true,
+        routing_algo: "XY"
+        noc_name: "quad_mesh_xy"
+        noc_array: [2, 2]
+      },
+      // number of pending transactions on the narrow/wide network
+      narrow_trans: 32,
+      wide_trans: 32,
+      // Disable for easier flow trials.
+      ro_cache_cfg: {
+          width: 1024,
+          count: 128,
+          sets: 2,
+          max_trans: 32,
+          address_regions: 4,
+      }
+      wide_xbar: {
+        max_slv_trans: 32,
+        max_mst_trans: 32,
+        fall_through: false,
+      },
+      // wide_xbar_slv_id_width: 3
+      narrow_xbar: {
+        max_slv_trans: 8,
+        max_mst_trans: 8,
+        fall_through: false,
+      },
+      // narrow_xbar_slv_id_width: 4,
+      // narrow_xbar_user_width: 3, // clog2(total number of clusters)
+      cfg_base_addr: 184549376, // 0x0b000000
+      cfg_base_offset: 65536, // 0x10000
+
+      
+    },
+    clusters:[
+      "snax_KUL_cluster",
+      "snax_KUL_cluster",
+      "snax_KUL_cluster",
+      "snax_KUL_cluster",
+      ],
+
+    // peripherals
+    peripherals: {
+        rom: {
+            address: 16777216, // 0x0100_0000
+            length: 131072, // 128 kiB 0x2_0000
+        },
+        clint: {
+                    address: 67108864, // 0x0400_0000
+                    length: 1048576, // 1 MiB 0x10_0000
+        },
+        axi_lite_peripherals: [
+            {
+                name: "debug",
+                address: 0, // 0x0000_0000
+                length: 4096, // 4 kiB 0x1000
+            }, 
+            {
+              name: "spis", // Only Master port, no slave port
+            }
+        ],
+        axi_lite_narrow_peripherals: [
+            {
+                name: "soc_ctrl",
+                address: 33554432, // 0x0200_0000
+                length: 4096, // 4 kiB 0x1000
+            },
+            {
+                name: "uart",
+                address: 33562624, // 0x0200_2000
+                length: 4096, // 4 kiB 0x1000
+            },
+            {
+                name: "gpio",
+                address:  33566720, // 0x0200_3000
+                length: 4096, // 4 kiB 0x1000
+            },
+            {
+                name: "i2c",
+                address: 33570816, // 0x0200_4000
+                length: 4096, // 4 kiB 0x1000
+            },
+            {
+                name: "chip_ctrl",
+                address: 33574912, // 0x0200_5000
+                length: 4096, // 4 kiB 0x1000
+            },
+            {
+                name: "timer",
+                address: 33579008, // 0x0200_6000
+                length: 4096, // 4 kiB 0x1000
+            },
+            {
+                name: "spim",
+                address: 50331648, // 0x0300_0000
+                length: 131072, // 4 kiB 0x2_0000
+            },
+            {
+                name: "plic",
+                address: 201326592, // 0x0C00_0000
+                length: 67108864, // 64 MiB 0x400_0000
+            },
+        ],
+    },
+    // non-peripheral IPs
+    spm_narrow: {
+      address: 1879048192, // 0x7000_0000
+      length: 131072, // 128 kiB 0x2_0000
+    },
+    spm_wide: {
+      address: 2147483648, // 0x8000_0000
+      length: 16777216, // 16 MiB 0x100_0000
+      banks: 32,
+    },
+    wide_zero_mem: {
+      address: 68719476736, // 0x10_0000_0000
+      length: 8589934592, // 8 GiB 0x11_0000_0000
+    },
+    sys_idma_cfg: {
+      address: 83886080, // 0x0500_0000
+      length: 65536, // 64 kiB 0x1_0000
+    },
+    // backup boot address
+    backup_boot_addr: 2147483648 // 0x8000_0000
+
+}

--- a/util/occamygen/occamy.py
+++ b/util/occamygen/occamy.py
@@ -2,14 +2,17 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+import subprocess
 import sys
 import math
+import importlib.util
 from pathlib import Path
 import hjson
 from jsonref import JsonRef
-sys.path.append(str(Path(__file__).parent / '../../deps/snitch_cluster/util/clustergen'))
+sys.path.append(str(Path(__file__).parent /
+                '../../deps/snitch_cluster/util/clustergen'))
 from cluster import Generator, PMA, PMACfg, SnitchCluster, clog2  # noqa: E402
-import subprocess
+
 
 def read_json_file(file):
     try:
@@ -20,37 +23,42 @@ def read_json_file(file):
         raise SystemExit(sys.exc_info()[1])
     return obj
 
+
 def generate_pma_cfg(occamy_cfg):
     pma_cfg = PMACfg()
     addr_width = occamy_cfg["addr_width"]
     # Make Wide SPM cacheable
     pma_cfg.add_region_length(PMA.CACHED,
-                                occamy_cfg["spm_wide"]["address"],
-                                occamy_cfg["spm_wide"]["length"],
-                                addr_width)
+                              occamy_cfg["spm_wide"]["address"],
+                              occamy_cfg["spm_wide"]["length"],
+                              addr_width)
     # Make the SPM cacheable
     pma_cfg.add_region_length(PMA.CACHED,
-                                occamy_cfg["spm_narrow"]["address"],
-                                occamy_cfg["spm_narrow"]["length"],
-                                addr_width)
+                              occamy_cfg["spm_narrow"]["address"],
+                              occamy_cfg["spm_narrow"]["length"],
+                              addr_width)
     # Make the boot ROM cacheable
     pma_cfg.add_region_length(PMA.CACHED,
-                                occamy_cfg["peripherals"]["rom"]["address"],
-                                occamy_cfg["peripherals"]["rom"]["length"],
-                                addr_width)
-    return pma_cfg  
+                              occamy_cfg["peripherals"]["rom"]["address"],
+                              occamy_cfg["peripherals"]["rom"]["length"],
+                              addr_width)
+    return pma_cfg
+
 
 def check_occamy_cfg(occamy_cfg):
     occamy_root = (Path(__file__).parent / "../../").resolve()
-    snitch_root = (Path(__file__).parent / "../../deps/snitch_cluster").resolve()
+    snitch_root = (Path(__file__).parent /
+                   "../../deps/snitch_cluster").resolve()
     schema = occamy_root / "docs/schema/occamy.schema.json"
     remote_schemas = [occamy_root / "docs/schema/axi_xbar.schema.json",
-                        occamy_root / "docs/schema/axi_tlb.schema.json",
-                        occamy_root / "docs/schema/address_range.schema.json",
-                        occamy_root / "docs/schema/peripherals.schema.json",
-                        snitch_root / "docs/schema/snitch_cluster.schema.json"]
-    generator_obj = Generator(schema,remote_schemas)
+                      occamy_root / "docs/schema/axi_tlb.schema.json",
+                      occamy_root / "docs/schema/address_range.schema.json",
+                      occamy_root / "docs/schema/peripherals.schema.json",
+                      snitch_root / "docs/schema/snitch_cluster.schema.json"]
+    generator_obj = Generator(schema, remote_schemas)
     generator_obj.validate(occamy_cfg)
+
+
 
 
 def get_cluster_generators(occamy_cfg, cluster_cfg_dir):
@@ -59,7 +67,7 @@ def get_cluster_generators(occamy_cfg, cluster_cfg_dir):
     cluster_name_list = occamy_cfg["clusters"]
     for cluster_name in cluster_name_list:
         cluster_cfg_path = cluster_cfg_dir / f"{cluster_name}.hjson"
-        with open(cluster_cfg_path,'r') as file:
+        with open(cluster_cfg_path, 'r') as file:
             cluster_cfg = read_json_file(file)
         # Now cluster_cfg has three field
         # cluster, dram, clint
@@ -67,10 +75,53 @@ def get_cluster_generators(occamy_cfg, cluster_cfg_dir):
         cluster_cfg = cluster_cfg["cluster"]
         # Add some field
         cluster_processing(cluster_cfg, occamy_cfg)
-        cluster_obj = SnitchCluster(cluster_cfg ,pma_cfg)
+        cluster_obj = SnitchCluster(cluster_cfg, pma_cfg)
         cluster_add_mem(cluster_obj, occamy_cfg)
         cluster_generators.append(cluster_obj)
     return cluster_generators
+
+
+def check_and_fix_occamy_xbar_id_width(occamy_cfg, cluster_generators):
+    # We take the cluster axi parameters from the first cluster
+    cluster_cfg = cluster_generators[0].cfg
+    # This is from line 78 of snitch_cluster/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+    # localparam int unsigned NrMasters = 3;
+    cluster_narrow_num_masters = 3
+    # This is from line 81 of snitch_cluster/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+    # localparam int unsigned NrDmaMasters = 3 + ${cfg['nr_hives']};
+    cluster_wide_num_masters = 3 + cluster_cfg["nr_hives"]
+
+    # cluster id/width
+    cluster_narrow_in_id_width = cluster_cfg["id_width_in"]
+    cluster_narrow_out_id_width = cluster_narrow_in_id_width + \
+        clog2(cluster_narrow_num_masters)
+    cluster_narrow_user_width = cluster_cfg["user_width"]
+    cluster_wide_in_id_width = cluster_cfg["dma_id_width_in"]
+    cluster_wide_out_id_width = cluster_wide_in_id_width + \
+        clog2(cluster_wide_num_masters)
+    cluster_wide_user_width = cluster_cfg["dma_user_width"]
+
+    # quadrant id/width
+    # Derive the quadrant_narrow_xbar_id from the cluster cfg
+    occamy_cfg["s1_quadrant"]["narrow_xbar_slv_id_width"] = cluster_narrow_out_id_width
+    # Derive the quadrant_narrow_xbar_user from the cluster cfg
+    occamy_cfg["s1_quadrant"]["narrow_xbar_slv_user_width"] = cluster_narrow_user_width
+    # Derive the quadrant_wide_xbar_id from the cluster cfg
+    occamy_cfg["s1_quadrant"]["wide_xbar_slv_id_width"] = cluster_wide_out_id_width
+    # Derive the quadrant_wide_xbar_user from the cluster cfg
+    occamy_cfg["s1_quadrant"]["wide_xbar_slv_user_width"] = cluster_wide_user_width
+    # Compute the quad xbar out id
+    num_clusters = len(occamy_cfg["clusters"])
+    quad_narrow_xbar_out_id = occamy_cfg["s1_quadrant"]["narrow_xbar_slv_id_width"] + clog2(num_clusters+1)
+    quad_wide_xbar_out_id = occamy_cfg["s1_quadrant"]["wide_xbar_slv_id_width"] + clog2(num_clusters+1)
+
+    # soc id/width
+    # occamy_cfg["narrow_xbar_slv_id_width"] = quad_narrow_xbar_out_id
+    occamy_cfg["narrow_xbar_slv_user_width"] = occamy_cfg["s1_quadrant"]["narrow_xbar_slv_user_width"]
+    # occamy_cfg["wide_xbar_slv_id_width"] = quad_wide_xbar_out_id + (
+    #         1 if occamy_cfg["s1_quadrant"].get("ro_cache_cfg") else 0)
+    occamy_cfg["wide_xbar_slv_user_width"] = occamy_cfg["s1_quadrant"]["wide_xbar_slv_user_width"]
+
 
 def get_cluster_cfg_list(occamy_cfg, cluster_cfg_dir):
     cluster_name_list = occamy_cfg["clusters"]
@@ -79,31 +130,92 @@ def get_cluster_cfg_list(occamy_cfg, cluster_cfg_dir):
         get_cluster_cfg_list.append(cluster_cfg_dir / f"{cluster_name}.hjson")
     return get_cluster_cfg_list
 
+
 def generate_snitch(cluster_cfg_dir, snitch_path):
     cluster_cfg_dir = set(cluster_cfg_dir)
     for cfg in cluster_cfg_dir:
         try:
-            subprocess.check_call(f"make -C {snitch_path}/target/snitch_cluster CFG_OVERRIDE={cfg} DISABLE_HEADER_GEN=true rtl-gen", shell=True)
+            subprocess.check_call(
+                f"make -C {snitch_path}/target/snitch_cluster CFG_OVERRIDE={cfg} DISABLE_HEADER_GEN=true rtl-gen", shell=True)
         except subprocess.CalledProcessError as e:
             print("Error! SNAX gen fails. Check the log.")
             raise
 
-def generate_wrappers(cluster_generators,out_dir):
+
+def generate_wrappers(cluster_generators, out_dir):
     for cluster_generator in cluster_generators:
         cluster_name = cluster_generator.cfg["name"]
         with open(out_dir / f"{cluster_name}_wrapper.sv", "w") as f:
             f.write(cluster_generator.render_wrapper())
 
-def generate_memories(cluster_generators,out_dir):
+
+def generate_memories(cluster_generators, out_dir):
     for cluster_generator in cluster_generators:
         cluster_name = cluster_generator.cfg["name"]
         with open(out_dir / f"{cluster_name}_memories.json", "w") as f:
             f.write(cluster_generator.memory_cfg())
 
+def generate_floonoc(floonoc_cfg, out_dir):
+    """
+    Generate the Floonoc sv from the cfg
+    :param floonoc_cfg: The floonoc cfg (generated from the template)
+    :param out_dir: The output directory
+    """
+    python_exec = sys.executable
+    try:
+        # Step0: Using bender to get the floonoc project dir
+        result = subprocess.run(
+            ["bender", "path", "floo_noc"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+        path = result.stdout.strip()
+        if not path:
+            raise RuntimeError("bender returns empty dir!")
+        floo_path = Path(path)
+        if not floo_path.exists():
+            raise FileNotFoundError(f"bender returns non-exist path: {path}")
+        # Step1: Using pip to install the floogen
+        spec = importlib.util.find_spec("floogen")
+        if spec is None:
+            print("Floogen is not installed!")
+            install_cmd = [python_exec, "-m", "pip", "install", "."]
+            print(f"Installing floogen: {' '.join(install_cmd)}")
+            result = subprocess.run(
+                install_cmd,
+                cwd=floo_path,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True
+            )
+            print("Install Success!")
+            print(result.stdout)
+        else:
+            print("Floogen has installed!")
+            print("Generating SV...")
+        # Step2: Using the floogen to generate the sv
+        cmd = [python_exec, "-m", "floogen.cli"]
+        cmd += ["-c", floonoc_cfg, "-o", out_dir]
+        subprocess.run(cmd, check=True)
+        print("Floogen is done.")
+    except subprocess.CalledProcessError as e:
+        print(f"Install Failed! Erro Code: {e.returncode}")
+        print("Stdout:")
+        print(e.stdout)
+        print("Stderror:")
+        print(e.stderr)
+        raise
+    except Exception as e:
+        print(f"Execution Failed: {str(e)}")
+        raise
+
 
 def cluster_processing(cluster_cfg, occamy_cfg):
     # in snith_cluster_wrapper.sv.tpl
-    #% if not cfg['tie_ports']:
+    # % if not cfg['tie_ports']:
     #   //-----------------------------
     #   // Cluster base addressing
     #   //-----------------------------
@@ -126,7 +238,6 @@ def cluster_processing(cluster_cfg, occamy_cfg):
     cluster_cfg["enable_debug"] = False
     # Set the vm_support to false, since do not need snitch (core-internal) virtual memory support
     cluster_cfg["vm_support"] = False
-
 
 
 def cluster_add_mem(cluster_obj, occamy_cfg):
@@ -191,7 +302,8 @@ def cluster_add_mem(cluster_obj, occamy_cfg):
                         byte_enable=True,
                         speed_optimized=True,
                         density_optimized=False)
-    
+
+
 def am_connect_soc_lite_periph_xbar(am, am_soc_axi_lite_periph_xbar, occamy_cfg):
     ########################
     # Periph AXI Lite XBar #
@@ -205,11 +317,11 @@ def am_connect_soc_lite_periph_xbar(am, am_soc_axi_lite_periph_xbar, occamy_cfg)
     for p in range(nr_axi_lite_peripherals):
         if "address" in occamy_cfg["peripherals"]["axi_lite_peripherals"][p]:
             am_axi_lite_peripherals.append(
-            am.new_leaf(
-                occamy_cfg["peripherals"]["axi_lite_peripherals"][p]["name"],
-                occamy_cfg["peripherals"]["axi_lite_peripherals"][p]["length"],
-                occamy_cfg["peripherals"]["axi_lite_peripherals"][p]["address"]
-            ).attach_to(am_soc_axi_lite_periph_xbar)
+                am.new_leaf(
+                    occamy_cfg["peripherals"]["axi_lite_peripherals"][p]["name"],
+                    occamy_cfg["peripherals"]["axi_lite_peripherals"][p]["length"],
+                    occamy_cfg["peripherals"]["axi_lite_peripherals"][p]["address"]
+                ).attach_to(am_soc_axi_lite_periph_xbar)
             )
 
     return am_axi_lite_peripherals
@@ -291,7 +403,8 @@ def am_connect_soc_wide_xbar_quad(am, am_soc_narrow_xbar, am_wide_xbar_quadrant_
         clusters_base_offset.append(
             cluster_generators[i].cfg["cluster_base_offset"])
         clusters_tcdm_size.append(
-            cluster_generators[i].cfg["tcdm"]["size"] * 1024)  # config is in KiB
+            # config is in KiB
+            cluster_generators[i].cfg["tcdm"]["size"] * 1024)
         clusters_periph_size.append(
             cluster_generators[i].cfg["cluster_periph_size"] * 1024)
         clusters_zero_mem_size.append(
@@ -311,7 +424,7 @@ def am_connect_soc_wide_xbar_quad(am, am_soc_narrow_xbar, am_wide_xbar_quadrant_
             bases_cluster = list()
             bases_cluster.append(cluster_i_start_addr +
                                  sum(clusters_base_offset[0:j+1]) + 0)
-            
+
             # TCDM is accessible from both narrow and wide xbar
             am_clusters.append(
                 am.new_leaf(
@@ -360,7 +473,8 @@ def am_connect_soc_wide_xbar_quad(am, am_soc_narrow_xbar, am_wide_xbar_quadrant_
             am_clusters.append(
                 am.new_leaf(
                     "quadrant_{}_cluster_{}_space_after_zero_mem".format(i, j),
-                    clusters_base_offset[j+1] - clusters_tcdm_size[j+1] - clusters_periph_size[j+1] - clusters_zero_mem_size[j+1],
+                    clusters_base_offset[j+1] - clusters_tcdm_size[j+1] -
+                    clusters_periph_size[j+1] - clusters_zero_mem_size[j+1],
                     *bases_cluster
                 ).attach_to(
                     am_wide_xbar_quadrant_s1[i]
@@ -378,6 +492,7 @@ def am_connect_soc_wide_xbar_quad(am, am_soc_narrow_xbar, am_wide_xbar_quadrant_
             am_soc_narrow_xbar
         )
     return am_clusters
+
 
 def get_dts(occamy_cfg, am_clint, am_axi_lite_peripherals, am_axi_lite_narrow_peripherals):
     dts = device_tree.DeviceTree()
@@ -499,6 +614,67 @@ def get_quadrant_kwargs(occamy_cfg, cluster_generators, soc_wide_xbar, soc_narro
         "narrow_xbar_quadrant_s1": narrow_xbar_quadrant_s1
     }
     return quadrant_kwargs
+
+
+def get_quadrant_noc_kwargs(occamy_cfg, cluster_generators):
+
+    # noc parameters
+    noc_name = occamy_cfg["s1_quadrant"]["noc_cfg"]["noc_name"]
+    routing_algo = occamy_cfg["s1_quadrant"]["noc_cfg"]["routing_algo"]
+    noc_array = occamy_cfg["s1_quadrant"]["noc_cfg"]["noc_array"]
+
+    # Check if the noc array size matches with the num of clusters
+    num_clusters = len(occamy_cfg["clusters"])
+    if num_clusters != noc_array[0]*noc_array[1]:
+        raise Exception(
+            "The noc array size must match with the num of clusters!")
+    # Add one col of the noc_array (since we need the default port)
+    noc_array[0] += 1
+
+    # We take the cluster axi parameters from the first cluster
+    cluster_cfg = cluster_generators[0].cfg
+    # This is from line 78 of snitch_cluster/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+    # localparam int unsigned NrMasters = 3;
+    cluster_narrow_num_masters = 3
+    # This is from line 81 of snitch_cluster/hw/snitch_cluster/src/snitch_cluster_wrapper.sv.tpl
+    # localparam int unsigned NrDmaMasters = 3 + ${cfg['nr_hives']};
+    cluster_wide_num_masters = 3 + cluster_cfg["nr_hives"]
+    # Narrow link
+    narrow_data_width = cluster_cfg["data_width"]
+    narrow_addr_width = cluster_cfg["addr_width"]
+    narrow_in_id_width = cluster_cfg["id_width_in"]
+    narrow_out_id_width = narrow_in_id_width + \
+        clog2(cluster_narrow_num_masters)
+    narrow_user_width = cluster_cfg["user_width"]
+    # wide link
+    wide_data_width = cluster_cfg["dma_data_width"]
+    wide_addr_width = cluster_cfg["addr_width"]
+    wide_in_id_width = cluster_cfg["dma_id_width_in"]
+    wide_out_id_width = wide_in_id_width + \
+        clog2(cluster_wide_num_masters)
+    wide_user_width = cluster_cfg["dma_user_width"]
+    # cluster
+    cluster_base_addr = cluster_cfg["cluster_base_addr"]
+    cluster_size = cluster_cfg["cluster_base_offset"]
+
+    quadrant_noc_kwargs = {
+        "noc_name": noc_name,
+        "noc_array": noc_array,
+        "routing_algo": routing_algo,
+        "narrow_data_width": narrow_data_width,
+        "narrow_addr_width": narrow_addr_width,
+        "narrow_in_id_width": narrow_in_id_width,
+        "narrow_out_id_width": narrow_out_id_width,
+        "narrow_user_width": narrow_user_width,
+        "wide_data_width": wide_data_width,
+        "wide_addr_width": wide_addr_width,
+        "wide_in_id_width": wide_in_id_width,
+        "wide_out_id_width": wide_out_id_width,
+        "wide_user_width": wide_user_width,
+        "cluster_base_addr": cluster_base_addr,
+        "cluster_size": cluster_size
+    }
+    return quadrant_noc_kwargs
 
 
 def get_xilinx_kwargs(occamy_cfg, soc_wide_xbar, soc_axi_lite_narrow_periph_xbar, name):
@@ -665,15 +841,17 @@ def get_bootdata_kwargs(occamy_cfg, cluster_generators, name):
     }
     return bootdata_kwargs
 
+
 def get_testharness_kwargs(soc_wide_xbar, soc_axi_lite_narrow_periph_xbar, chip_id, solder, name):
     testharness_kwargs = {
         "name": name,
         "solder": solder,
-        "chip_id": chip_id, 
+        "chip_id": chip_id,
         "soc_wide_xbar": soc_wide_xbar,
         "soc_axi_lite_narrow_periph_xbar": soc_axi_lite_narrow_periph_xbar
     }
     return testharness_kwargs
+
 
 def get_multichip_testharness_kwargs(occamy_cfg, soc2router_bus, router2soc_bus, name):
     testharness_kwargs = {
@@ -684,6 +862,7 @@ def get_multichip_testharness_kwargs(occamy_cfg, soc2router_bus, router2soc_bus,
         "mem_size": occamy_cfg["spm_wide"]["length"]
     }
     return testharness_kwargs
+
 
 def get_chip_kwargs(soc_wide_xbar, soc_axi_lite_narrow_periph_xbar, soc2router_bus, router2soc_bus, occamy_cfg, cluster_generators, util, name):
     core_per_cluster_list = [cluster_generator.cfg["nr_cores"]

--- a/util/occamygen/occamygen.py
+++ b/util/occamygen/occamygen.py
@@ -86,6 +86,9 @@ def main():
     parser.add_argument("--quadrant-s1-ctrl",
                         metavar="QUADRANT_S1_CTL",
                         help="Name of S1 quadrant controller template file (output)")
+    parser.add_argument("--quadrant-s1-noc",
+                        metavar="QUADRANT_S1_NOC",
+                        help="Name of S1 quadrant NoC template file (output)")
     parser.add_argument("--xilinx-sv",
                         metavar="XILINX_SV",
                         help="Name of the Xilinx wrapper file (output).")
@@ -166,6 +169,9 @@ def main():
 
     cluster_cfg_dir = occamy_root / "deps/snitch_cluster/target/snitch_cluster/cfg"
     cluster_generators = occamy.get_cluster_generators(occamy_cfg, cluster_cfg_dir)
+
+    # Check and fix the xbar id/width
+    occamy.check_and_fix_occamy_xbar_id_width(occamy_cfg, cluster_generators)
     # Each cluster will be generated seperately
     # The generated file's name is specified in the ["name"] field of each cluster's cfg file
     # e.g
@@ -322,8 +328,8 @@ def main():
         48,
         512,
         # This is the cleanest solution minimizing ID width conversions
-        occamy_cfg["quadrant_inter_xbar_slv_id_width_no_rocache"] + (
-            1 if occamy_cfg["s1_quadrant"].get("ro_cache_cfg") else 0),
+        iw=occamy_cfg["wide_xbar_slv_id_width"],
+        uw=occamy_cfg["wide_xbar_slv_user_width"],
         chipidw=occamy_cfg["hemaia_multichip"]["chip_id_width"],
         name="soc_wide_xbar",
         clk="clk_i",
@@ -360,8 +366,8 @@ def main():
     soc_narrow_xbar = solder.AxiXbar(
         48,
         64,
-        occamy_cfg["narrow_xbar_slv_id_width"],
-        occamy_cfg["narrow_xbar_user_width"],
+        iw=occamy_cfg["narrow_xbar_slv_id_width"],
+        uw=occamy_cfg["narrow_xbar_slv_user_width"],
         chipidw=occamy_cfg["hemaia_multichip"]["chip_id_width"],
         name="soc_narrow_xbar",
         clk="clk_i",
@@ -451,7 +457,8 @@ def main():
     wide_xbar_quadrant_s1 = solder.AxiXbar(
         48,
         512,
-        occamy_cfg["s1_quadrant"]["wide_xbar_slv_id_width"],
+        iw=occamy_cfg["s1_quadrant"]["wide_xbar_slv_id_width"],
+        uw=occamy_cfg["s1_quadrant"]["wide_xbar_slv_user_width"],
         chipidw=occamy_cfg["hemaia_multichip"]["chip_id_width"],
         name="wide_xbar_quadrant_s1",
         clk="clk_quadrant_uncore",
@@ -467,8 +474,8 @@ def main():
     narrow_xbar_quadrant_s1 = solder.AxiXbar(
         48,
         64,
-        occamy_cfg["s1_quadrant"]["narrow_xbar_slv_id_width"],
-        occamy_cfg["s1_quadrant"]["narrow_xbar_user_width"],
+        iw=occamy_cfg["s1_quadrant"]["narrow_xbar_slv_id_width"],
+        uw=occamy_cfg["s1_quadrant"]["narrow_xbar_slv_user_width"],
         chipidw=occamy_cfg["hemaia_multichip"]["chip_id_width"],
         name="narrow_xbar_quadrant_s1",
         clk="clk_quadrant_uncore",
@@ -581,6 +588,16 @@ def main():
                     print(outdir, args.name)
                     with open("{}/{}_quadrant_s1.sv".format(outdir, args.name), 'w') as f:
                         f.write("// no quadrants in this design")
+    ###################
+    # S1 Quadrant NoC #
+    ###################
+    if args.quadrant_s1_noc:
+        quadrant_s1_noc_kwargs = occamy.get_quadrant_noc_kwargs(occamy_cfg, cluster_generators)
+        write_template(args.quadrant_s1_noc,
+                       outdir,
+                       fname="{}_quad_noc.yml".format(args.name),
+                       **quadrant_s1_noc_kwargs)
+        occamy.generate_floonoc(f"{outdir}/{args.name}_quad_noc.yml", outdir)
 
     ##################
     # Xilinx Wrapper #


### PR DESCRIPTION
This PR adds the floonoc support to the HeMAiA.
### Implementations
The sequence of generating the Floonoc SV are:
1. Bender fetches the floonoc repo
2. The `target/rtl/src/occamy_quad_noc.yml` is generated from the `hw/occamy/quad_noc/quad_noc.yml.tpl`
3. Install the `floogen` script from the floonoc repo
4. Using the `floogen` to generate the sv based on the yaml file "occamy_quad_noc.yml"

### System Integration
The system integration codes are in the `hw/occamy/occamy_quadrant_s1.sv.tpl`, where the floonoc is implemented at the quadrant level. 

User can specify the `noc_cfg` field in the system hjson to enable the floonoc
```
    s1_quadrant: {
      noc_cfg: {
        en_floonoc: true,
        routing_algo: "XY"
        noc_name: "quad_mesh_xy"
        noc_array: [2, 2]
      }, 
```
### AXI ID Derivation
Besides, this PR also adds the support to derive the xbar id width from the cluster configuration. 

A new function `check_and_fix_occamy_xbar_id_width` is implemented at `occamy.py` to derive the needed AXI ID.