### PR TITLE
New FPGA Synthesis & Implementation Script

### DIFF
--- a/target/fpga_chip/hemaia_system/hemaia_system_vcu128_impl.xdc
+++ b/target/fpga_chip/hemaia_system/hemaia_system_vcu128_impl.xdc
@@ -109,7 +109,8 @@ set_clock_groups -asynchronous \
     -group {clk_main} \
     -group {clk_core} \
     -group {clk_acc} \
-    -group {clk_peri}
+    -group {clk_peri} \
+    -group {spi_s_sck}
 
 # CDC 2phase clearable of DM: i_cdc_resp/i_cdc_req
 # CONSTRAINT: Requires max_delay of min_period(src_clk_i, dst_clk_i) through the paths async_req, async_ack, async_data.

--- a/target/fpga_chip/hemaia_system/hemaia_system_vpk180_impl.xdc
+++ b/target/fpga_chip/hemaia_system/hemaia_system_vpk180_impl.xdc
@@ -110,7 +110,8 @@ set_clock_groups -asynchronous \
     -group {clk_core} \
     -group {clk_acc} \
     -group {clk_pl_1} \
-    -group {clk_pl_2 clk_peri}
+    -group {clk_pl_2 clk_peri} \
+    -group {spi_s_sck}
 
 # CDC 2phase clearable of DM: i_cdc_resp/i_cdc_req
 # CONSTRAINT: Requires max_delay of min_period(src_clk_i, dst_clk_i) through the paths async_req, async_ack, async_data.


### PR DESCRIPTION
This PR modified the FPGA synthesis & implementation script to encompass the new **hemaia_clk_rst_manager** into FPGA prototype. The FPGA main clock is set at 300MHz while the default constraint assumes the division is set at 6. 