### PR TITLE
Add idle programs for testing

### DIFF
--- a/target/sim/sw/host/Makefile
+++ b/target/sim/sw/host/Makefile
@@ -6,6 +6,12 @@
 
 # Add user applications to APPS variable
 APPS  = hello_world
+APPS += idle_cluster_0
+APPS += idle_cluster_1
+APPS += idle_cluster_2
+APPS += idle_cluster_3
+APPS += idle_all_clk_off
+APPS += idle_all_clk_on
 APPS += offload
 
 TARGET ?= all

--- a/target/sim/sw/host/apps/idle_all_clk_off/Makefile
+++ b/target/sim/sw/host/apps/idle_all_clk_off/Makefile
@@ -1,0 +1,10 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Luca Colagrande <colluca@iis.ee.ethz.ch>
+
+APP  = idle_all_clk_off
+SRCS = src/idle_all_clk_off.c
+
+include ../common.mk

--- a/target/sim/sw/host/apps/idle_all_clk_off/src/idle_all_clk_off.c
+++ b/target/sim/sw/host/apps/idle_all_clk_off/src/idle_all_clk_off.c
@@ -1,0 +1,22 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdio.h>
+#include "host.c"
+
+// Frequency at which the UART peripheral is clocked
+int main() {
+    init_uart(32, 1);
+    asm volatile("fence" : : : "memory");
+    print_uart("IDLE ALL CLK OFF \r\n");
+
+    // Enable clock for cluster 0 and uncore
+    reset_and_ungate_quadrants(0x00);
+    deisolate_all();
+
+    // Wait for a certain amount of time for simulation purposes
+    for (int i = 0; i < 100000; i++) asm volatile("nop" : : : "memory");
+
+    return 0;
+}

--- a/target/sim/sw/host/apps/idle_all_clk_on/Makefile
+++ b/target/sim/sw/host/apps/idle_all_clk_on/Makefile
@@ -1,0 +1,10 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Luca Colagrande <colluca@iis.ee.ethz.ch>
+
+APP  = idle_all_clk_on
+SRCS = src/idle_all_clk_on.c
+
+include ../common.mk

--- a/target/sim/sw/host/apps/idle_all_clk_on/src/idle_all_clk_on.c
+++ b/target/sim/sw/host/apps/idle_all_clk_on/src/idle_all_clk_on.c
@@ -1,0 +1,22 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdio.h>
+#include "host.c"
+
+// Frequency at which the UART peripheral is clocked
+int main() {
+    init_uart(32, 1);
+    asm volatile("fence" : : : "memory");
+    print_uart("IDLE ALL CLK ON \r\n");
+
+    // Enable clock for cluster 0 and uncore
+    reset_and_ungate_quadrants(0x1f);
+    deisolate_all();
+
+    // Wait for a certain amount of time for simulation purposes
+    for (int i = 0; i < 100000; i++) asm volatile("nop" : : : "memory");
+
+    return 0;
+}

--- a/target/sim/sw/host/apps/idle_cluster_0/Makefile
+++ b/target/sim/sw/host/apps/idle_cluster_0/Makefile
@@ -1,0 +1,10 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Luca Colagrande <colluca@iis.ee.ethz.ch>
+
+APP  = idle_cluster_0
+SRCS = src/idle_cluster_0.c
+
+include ../common.mk

--- a/target/sim/sw/host/apps/idle_cluster_0/src/idle_cluster_0.c
+++ b/target/sim/sw/host/apps/idle_cluster_0/src/idle_cluster_0.c
@@ -1,0 +1,22 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdio.h>
+#include "host.c"
+
+// Frequency at which the UART peripheral is clocked
+int main() {
+    init_uart(32, 1);
+    asm volatile("fence" : : : "memory");
+    print_uart("IDLE CUSTER 0 \r\n");
+
+    // Enable clock for cluster 0 and uncore
+    reset_and_ungate_quadrants(0x11);
+    deisolate_all();
+
+    // Wait for a certain amount of time for simulation purposes
+    for (int i = 0; i < 100000; i++) asm volatile("nop" : : : "memory");
+
+    return 0;
+}

--- a/target/sim/sw/host/apps/idle_cluster_1/Makefile
+++ b/target/sim/sw/host/apps/idle_cluster_1/Makefile
@@ -1,0 +1,10 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Luca Colagrande <colluca@iis.ee.ethz.ch>
+
+APP  = idle_cluster_1
+SRCS = src/idle_cluster_1.c
+
+include ../common.mk

--- a/target/sim/sw/host/apps/idle_cluster_1/src/idle_cluster_1.c
+++ b/target/sim/sw/host/apps/idle_cluster_1/src/idle_cluster_1.c
@@ -1,0 +1,22 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdio.h>
+#include "host.c"
+
+// Frequency at which the UART peripheral is clocked
+int main() {
+    init_uart(32, 1);
+    asm volatile("fence" : : : "memory");
+    print_uart("IDLE CUSTER 1 \r\n");
+
+    // Enable clock for cluster 0 and uncore
+    reset_and_ungate_quadrants(0x12);
+    deisolate_all();
+
+    // Wait for a certain amount of time for simulation purposes
+    for (int i = 0; i < 100000; i++) asm volatile("nop" : : : "memory");
+
+    return 0;
+}

--- a/target/sim/sw/host/apps/idle_cluster_2/Makefile
+++ b/target/sim/sw/host/apps/idle_cluster_2/Makefile
@@ -1,0 +1,10 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Luca Colagrande <colluca@iis.ee.ethz.ch>
+
+APP  = idle_cluster_2
+SRCS = src/idle_cluster_2.c
+
+include ../common.mk

--- a/target/sim/sw/host/apps/idle_cluster_2/src/idle_cluster_2.c
+++ b/target/sim/sw/host/apps/idle_cluster_2/src/idle_cluster_2.c
@@ -1,0 +1,22 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdio.h>
+#include "host.c"
+
+// Frequency at which the UART peripheral is clocked
+int main() {
+    init_uart(32, 1);
+    asm volatile("fence" : : : "memory");
+    print_uart("IDLE CUSTER 2 \r\n");
+
+    // Enable clock for cluster 0 and uncore
+    reset_and_ungate_quadrants(0x14);
+    deisolate_all();
+
+    // Wait for a certain amount of time for simulation purposes
+    for (int i = 0; i < 100000; i++) asm volatile("nop" : : : "memory");
+
+    return 0;
+}

--- a/target/sim/sw/host/apps/idle_cluster_3/Makefile
+++ b/target/sim/sw/host/apps/idle_cluster_3/Makefile
@@ -1,0 +1,10 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Luca Colagrande <colluca@iis.ee.ethz.ch>
+
+APP  = idle_cluster_3
+SRCS = src/idle_cluster_3.c
+
+include ../common.mk

--- a/target/sim/sw/host/apps/idle_cluster_3/src/idle_cluster_3.c
+++ b/target/sim/sw/host/apps/idle_cluster_3/src/idle_cluster_3.c
@@ -1,0 +1,22 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdio.h>
+#include "host.c"
+
+// Frequency at which the UART peripheral is clocked
+int main() {
+    init_uart(32, 1);
+    asm volatile("fence" : : : "memory");
+    print_uart("IDLE CUSTER 0 \r\n");
+
+    // Enable clock for cluster 0 and uncore
+    reset_and_ungate_quadrants(0x18);
+    deisolate_all();
+
+    // Wait for a certain amount of time for simulation purposes
+    for (int i = 0; i < 100000; i++) asm volatile("nop" : : : "memory");
+
+    return 0;
+}


### PR DESCRIPTION
These are simple programs that switch on the clocks but do not process any data. The CVA6 is stuck on a long nop cycle.

Major TODO:
- [x] Add idle where CVA6 clock is only on
- [x] Add idle where all clocks are on
- [x] Add idle where CVA6 + cluster 0 only clks
- [x] Add idle where CVA6 + cluster 1 only clks
- [x] Add idle where CVA6 + cluster 2 only clks
- [x] Add idle where CVA6 + cluster 3 only clks