### PR TITLE
SW Bug Fix

### DIFF
--- a/target/sw/shared/platform/template/occamy_memory_map.h.tpl
+++ b/target/sw/shared/platform/template/occamy_memory_map.h.tpl
@@ -45,8 +45,13 @@
 #define soc_ctrl_scratch_base \
     (SOC_CTRL_BASE_ADDR + OCCAMY_SOC_SCRATCH_0_REG_OFFSET)
 
+%if nr_clusters==1:
+#define soc_ctrl_mailbox_scratch_base \
+    (SOC_CTRL_BASE_ADDR + OCCAMY_SOC_MAILBOX_SCRATCH_REG_OFFSET)
+%else:
 #define soc_ctrl_mailbox_scratch_base \
     (SOC_CTRL_BASE_ADDR + OCCAMY_SOC_MAILBOX_SCRATCH_0_REG_OFFSET)
+%endif
 
 #define soc_ctrl_kernel_tab_scratch_base \
     (SOC_CTRL_BASE_ADDR + OCCAMY_SOC_KERNEL_TAB_SCRATCH_0_REG_OFFSET)    


### PR DESCRIPTION
This PR fixes a bug in sw generation when nr_cluster=1

The key modification is the `target/sw/shared/platform/template/occamy_memory_map.h.tpl` file.

At the case of nr_cluster=1, the reg_gen will generate a different name for the REG_OFFSET, without the "0" for the multireg configuration. 