### PR TITLE
Change bingo_hw_manager branch from dev to main

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -37,7 +37,7 @@ dependencies:
   hemaia_d2d_link:            { git:  https://github.com/KULeuven-MICAS/hemaia_d2d_link.git,            rev:     main    }
   hemaia_clk_rst_controller:  { git:  https://github.com/KULeuven-MICAS/hemaia_clk_rst_controller.git,  rev:     main     }
   floo_noc:                   { git:  https://github.com/KULeuven-MICAS/FlooNoC.git,                    rev:     main    }
-  bingo_hw_manager:           { git:  https://github.com/KULeuven-MICAS/bingo_hw_manager.git,           rev:     dev     }
+  bingo_hw_manager:           { git:  https://github.com/KULeuven-MICAS/bingo_hw_manager.git,           rev:     main     }
 
 workspace:
   package_links:


### PR DESCRIPTION
This pull request makes a small update to the `Bender.yml` dependencies, switching the `bingo_hw_manager` dependency from the `dev` branch to the `main` branch. This ensures that the project uses the stable version of `bingo_hw_manager`.