### PR TITLE
SW: GEMM precision kernels, accumPrevC, and the GEMM sweep

### DIFF
--- a/target/sim/automation/sweep/gemm/gather_gemm_luts.py
+++ b/target/sim/automation/sweep/gemm/gather_gemm_luts.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fanchen Kong <fanchen.kong@kuleuven.be>
+#
+# Gather per-(precision, shape) VersaCore GEMM cycle measurements into a CSV.
+#
+# After run_gemm_sweep.py finishes, each gemm_psweep_<prec>_1cluster task has run
+# in its own gemm/task_<idx>/bin/ dir. The device GEMM kernels carry no UART
+# timing -- they bracket compute with the magic-NOP markers
+# BINGO_TRACE_GEMM_FULL_RUN_START/END (perf_tracing.h, on by default). Each task
+# sweeps the shared (M,K,N,array_shape) grid in one sim, emitting one
+# GEMM_FULL_RUN event per config (in CONFIGS order). For every task this script
+# (mirroring gather_xdma_luts.py):
+#   1. converts the cluster-core traces (.dasm -> .txt via spike-dasm |
+#      util/trace/gen_trace.py --permissive),
+#   2. runs util/bingo_trace/bingo_trace.py to emit bingo_trace.json,
+#   3. reads the ordered GEMM_FULL_RUN dur_cc values,
+#   4. pairs the Nth value with the workload's configs.json[N] = (M,K,N,shape)
+#      and the precision (from configs.json),
+#   5. writes one CSV: op_name,op_node,prec,array_shape,M,K,N,cycles.
+#
+# The `prec` column is the GEMM precision (i8i8_i32 / i8i4_i32 / i4i4_i32 /
+# i8i8_i8 / i8i4_f16) -- the axis the co-design / curve-fitting step pairs with
+# the Ara LUT. task_<idx> -> workload mapping follows task_gemm.yaml order.
+
+import argparse
+import csv
+import json
+import os
+import sys
+
+_THIS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.normpath(os.path.join(_THIS, "../../../../../"))
+sys.path.insert(0, os.path.join(_ROOT, "util/automation_scripts"))
+from bingo_trace_gather import (  # noqa: E402
+    convert_traces, extract_run_cycles, parse_task_order, run_bingo_trace,
+)
+
+_WORKLOADS = os.path.join(
+    _ROOT, "target/sw/host/apps/offload_bingo_hw/single_chip/workloads")
+_DEFAULT_OUT = os.path.join(_THIS, "gemm_cycles.csv")
+
+OP_NAME = "gemm_full"
+# precision -> device wrapper symbol that produced the measurement.
+PREC_KERNEL = {
+    "i8i8_i32": "__snax_bingo_kernel_gemm_i8i8_i32",
+    "i8i4_i32": "__snax_bingo_kernel_gemm_i8i4_i32",
+    "i4i4_i32": "__snax_bingo_kernel_gemm_i4i4_i32",
+    "i8i8_i8":  "__snax_bingo_kernel_gemm_i8i8_i8",
+    "i8i4_f16": "__snax_bingo_kernel_gemm_i8i4_f16",
+    "i8i8_f16": "__snax_bingo_kernel_gemm_i8i8_f16",
+}
+
+
+def gather_one(workload, idx, ci_dir, verbose=True):
+    logs_dir = os.path.join(ci_dir, f"task_{idx}", "bin", "logs")
+    cfg_path = os.path.join(_WORKLOADS, workload, "configs.json")
+    if not os.path.isdir(logs_dir):
+        print(f"task_{idx} {workload}: MISSING logs dir {logs_dir}")
+        return []
+    if not os.path.exists(cfg_path):
+        print(f"task_{idx} {workload}: MISSING configs.json {cfg_path}")
+        return []
+    with open(cfg_path) as f:
+        cj = json.load(f)
+    prec = cj.get("precision", "?")
+    configs = cj["configs"]
+    op_node = PREC_KERNEL.get(prec, f"__snax_bingo_kernel_gemm_{prec}")
+
+    convert_traces(logs_dir, verbose)
+    bingo_json = run_bingo_trace(logs_dir)
+    if not bingo_json:
+        return []
+    cycles = extract_run_cycles(bingo_json, "GEMM_FULL_RUN")
+    if len(cycles) != len(configs):
+        print(f"task_{idx} {workload}: {len(cycles)} GEMM_FULL_RUN events vs "
+              f"{len(configs)} configs (pairing first {min(len(cycles), len(configs))})")
+
+    rows = []
+    for (M, K, N, shape), cyc in zip(configs, cycles):
+        rows.append({"op_name": OP_NAME, "op_node": op_node, "prec": prec,
+                     "array_shape": shape, "M": M, "K": K, "N": N, "cycles": cyc})
+    if verbose:
+        pts = ", ".join(f"({r['M']},{r['K']},{r['N']},s{r['array_shape']}):{r['cycles']}"
+                        for r in rows)
+        print(f"task_{idx} {workload} [{prec}]: {len(rows)} points  [{pts}]")
+    return rows
+
+
+def gather_all(task_yaml, ci_dir, out_csv, verbose=True):
+    order = parse_task_order(task_yaml)
+    print(f"Expected {len(order)} gemm tasks from {os.path.basename(task_yaml)}")
+    rows = []
+    for idx, workload in enumerate(order):
+        rows.extend(gather_one(workload, idx, ci_dir, verbose))
+    if rows:
+        os.makedirs(os.path.dirname(os.path.abspath(out_csv)), exist_ok=True)
+        fields = ["op_name", "op_node", "prec", "array_shape", "M", "K", "N", "cycles"]
+        with open(out_csv, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=fields)
+            w.writeheader()
+            w.writerows(rows)
+    return len(rows)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--task-yaml", default=os.path.join(_THIS, "task_gemm.yaml"))
+    ap.add_argument("--ci-dir", default=_THIS,
+                    help="dir holding the task_<idx> run dirs (default: this dir)")
+    ap.add_argument("--out", default=_DEFAULT_OUT, help="output CSV (default: %(default)s)")
+    args = ap.parse_args()
+    n = gather_all(args.task_yaml, args.ci_dir, args.out)
+    print(f"\nWrote {n} row(s) to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/target/sim/automation/sweep/gemm/run_gemm_sweep.py
+++ b/target/sim/automation/sweep/gemm/run_gemm_sweep.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fanchen Kong <fanchen.kong@kuleuven.be>
+"""
+HeMAiA VersaCore GEMM precision LUT sweep runner.
+
+Builds and runs ``task_gemm.yaml`` (one task per precision) through the shared
+:class:`HeMAiASimRunner`, using the single-chip config — same pattern as the
+xDMA/ara sweeps. Each task is a ``gemm_psweep_<prec>_1cluster`` workload that
+sweeps the shared (M,K,N,array_shape) grid in ONE sim (precision can't be looped
+in one binary), so the 5 precisions run in parallel.
+
+After this finishes, post-process the per-task traces into a cycle CSV:
+
+    python3 gather_gemm_luts.py    # -> gemm_cycles.csv  (per precision x shape)
+
+    python3 run_gemm_sweep.py [-j JOBS] [-f task.yaml] [--engine vcs|vsim] [--waveform 0|1]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[5] / "util" / "automation_scripts"))
+from sweep_runner import run_sweep_cli  # noqa: E402
+
+if __name__ == "__main__":
+    run_sweep_cli(
+        __file__,
+        description="Build and run the HeMAiA GEMM precision LUT sweep.",
+        default_task_name="task_gemm.yaml",
+    )

--- a/target/sim/automation/sweep/gemm/task_gemm.yaml
+++ b/target/sim/automation/sweep/gemm/task_gemm.yaml
@@ -1,0 +1,31 @@
+# VersaCore GEMM precision-sweep tasks — one per precision, run in parallel.
+# Run with: python3 run_gemm_sweep.py -j <N>   (then python3 gather_gemm_luts.py)
+# Each workload sweeps the shared (M,K,N,array_shape) grid in gemm_psweep_lib.CONFIGS
+# via its precision wrapper kernel and emits one BINGO_TRACE_GEMM_FULL_RUN event +
+# a configs.json per config; gather_gemm_luts.py pairs them into a per-(precision,
+# shape) cycle CSV. All single_chip -> run on chip00.
+runs:
+  - HOST_APP_TYPE: offload_bingo_hw
+    CHIP_TYPE: single_chip
+    WORKLOAD: gemm_psweep_i8i8_i32_1cluster
+    DEV_APP: snax-bingo-offload
+  - HOST_APP_TYPE: offload_bingo_hw
+    CHIP_TYPE: single_chip
+    WORKLOAD: gemm_psweep_i8i4_i32_1cluster
+    DEV_APP: snax-bingo-offload
+  - HOST_APP_TYPE: offload_bingo_hw
+    CHIP_TYPE: single_chip
+    WORKLOAD: gemm_psweep_i4i4_i32_1cluster
+    DEV_APP: snax-bingo-offload
+  - HOST_APP_TYPE: offload_bingo_hw
+    CHIP_TYPE: single_chip
+    WORKLOAD: gemm_psweep_i8i8_i8_1cluster
+    DEV_APP: snax-bingo-offload
+  - HOST_APP_TYPE: offload_bingo_hw
+    CHIP_TYPE: single_chip
+    WORKLOAD: gemm_psweep_i8i4_f16_1cluster
+    DEV_APP: snax-bingo-offload
+  - HOST_APP_TYPE: offload_bingo_hw
+    CHIP_TYPE: single_chip
+    WORKLOAD: gemm_psweep_i8i8_f16_1cluster
+    DEV_APP: snax-bingo-offload

--- a/target/sim/automation/sweep/versacore/testing_launch.py
+++ b/target/sim/automation/sweep/versacore/testing_launch.py
@@ -38,27 +38,13 @@ DEFAULT_WORKLOAD_CSV = SCRIPT_DIR / "testing_workload.csv"
 DEFAULT_RESULTS_CSV = SCRIPT_DIR / "testing_results.csv"
 DEFAULT_LOG_DIR = SCRIPT_DIR / "logs"
 UART_LOG_PATH = REPO_ROOT / "target/sim/bin/uart_chip_0_0.log"
-HOST_CHECK_PASS_RE = re.compile(r"\[Host\]\s+Check\s+\[[^\]]+\]:\s+PASS\s+\(64 bytes\)")
+# Output size varies by shape and precision (the check covers min(64, D_size)
+# bytes), so match any byte count rather than a fixed 64.
+HOST_CHECK_PASS_RE = re.compile(r"\[Host\]\s+Check\s+\[[^\]]+\]:\s+PASS\s+\(\d+ bytes\)")
 
 sys.path.insert(0, str(REPO_ROOT / "util" / "automation_scripts"))
-
-PARAM_FIELDS = [
-    "num_clusters",
-    "array_shape",
-    "data_type",
-    "transposed_A",
-    "transposed_B",
-    "int4_a_enable",
-    "int4_b_enable",
-    "K",
-    "N",
-    "M",
-    "addNonZeroC",
-    "addZeroC",
-    "accumPrevC",
-    "quantization_enable",
-    "int32tofp16_enable",
-]
+sys.path.insert(0, str(SCRIPT_DIR))
+from versacore_params import PARAM_FIELDS  # noqa: E402
 
 RESULT_FIELDS = [
     "test_name",

--- a/target/sim/automation/sweep/versacore/testing_workload_gen.py
+++ b/target/sim/automation/sweep/versacore/testing_workload_gen.py
@@ -19,6 +19,7 @@ import hjson
 
 REPO_ROOT = Path(__file__).resolve().parents[5]
 sys.path.append(str(REPO_ROOT / "util/sim"))
+import _usg_paths  # noqa: F401,E402  (registers util/sim/{common,gemm,xdma,ara} on sys.path)
 from gemm_sim_utils import (  # noqa E402
     _bytes_for_elements,
     _gemm_operand_widths,
@@ -29,23 +30,8 @@ L1_MEMORY_LIMIT_BYTES = int(512 * 1024 * 0.4) # 60% of 512KB to leave some room 
 L3_MEMORY_LIMIT_BYTES = int(40 * 1024) # 40KB heap
 DEFAULT_CSV = Path(__file__).with_name("testing_workload.csv")
 
-PARAM_FIELDS = [
-    "num_clusters",
-    "array_shape",
-    "data_type",
-    "transposed_A",
-    "transposed_B",
-    "int4_a_enable",
-    "int4_b_enable",
-    "K",
-    "N",
-    "M",
-    "addNonZeroC",
-    "addZeroC",
-    "accumPrevC",
-    "quantization_enable",
-    "int32tofp16_enable",
-]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from versacore_params import PARAM_FIELDS  # noqa: E402
 
 CSV_FIELDS = ["test_name", "suite", "operand_bytes"] + PARAM_FIELDS
 
@@ -65,6 +51,39 @@ BASE_PARAMS = {
     "accumPrevC": 0,
     "quantization_enable": 0,
     "int32tofp16_enable": 0,
+}
+
+
+# ---------------------------------------------------------------------------
+# GEMM precision contract
+# ---------------------------------------------------------------------------
+# Single source of truth for "which precision" -> the VersaCore params flags that
+# select it on the Int8 (snax_versacore_to_cluster) build. The core precision is
+# passed as data_type (the DATA_TYPE_CFG CSR via set_versacore_csr) plus the SW
+# packing/output flags below; datagen.py + the kernel consume them. Each entry is
+# one test suite. `derive_from` reuses another suite's exact shapes (apples-to-
+# apples across precisions) and only adds the extra output-stage flag.
+#
+#   base_int8            : int8 x int8 -> int32   (baseline)
+#   int4_b               : int4 x int8 -> int32   (int4_b_enable: pack B to 4-bit)
+#   int4_ab              : int4 x int4 -> int32   (int4_a_enable + int4_b_enable)
+#   quantized            : int8 x int8 -> int8    (quantization_enable: int32->int8)
+#   int4_b_int32_to_fp16 : int4 x int8 -> fp16    (int4_b_enable + int32tofp16_enable)
+#   int8_int32_to_fp16   : int8 x int8 -> fp16    (int32tofp16_enable, no input packing)
+GEMM_PRECISIONS = {
+    "base_int8":            {"array_shapes": (0, 1, 2), "overrides": {},
+                             "derive_from": None},
+    "int4_b":               {"array_shapes": (0, 1, 2), "overrides": {"int4_b_enable": 1},
+                             "derive_from": None},
+    "int4_ab":              {"array_shapes": (0, 2),
+                             "overrides": {"int4_a_enable": 1, "int4_b_enable": 1},
+                             "derive_from": None},
+    "quantized":            {"overrides": {"quantization_enable": 1},
+                             "derive_from": "base_int8"},
+    "int4_b_int32_to_fp16": {"overrides": {"int32tofp16_enable": 1},
+                             "derive_from": "int4_b"},
+    "int8_int32_to_fp16":   {"overrides": {"int32tofp16_enable": 1},
+                             "derive_from": "base_int8"},
 }
 
 
@@ -196,50 +215,6 @@ def valid_shape_rows(
                         }
 
 
-def generate_base_int8_shapes(
-    hwcfg: dict,
-    l1_memory_limit: int,
-    l3_memory_limit: int,
-) -> Iterable[dict]:
-    return valid_shape_rows(
-        hwcfg,
-        suite="base_int8",
-        array_shapes=(0, 1, 2),
-        l1_memory_limit=l1_memory_limit,
-        l3_memory_limit=l3_memory_limit,
-    )
-
-
-def generate_int4_b_shapes(
-    hwcfg: dict,
-    l1_memory_limit: int,
-    l3_memory_limit: int,
-) -> Iterable[dict]:
-    return valid_shape_rows(
-        hwcfg,
-        suite="int4_b",
-        array_shapes=(0, 1, 2),
-        overrides={"int4_b_enable": 1},
-        l1_memory_limit=l1_memory_limit,
-        l3_memory_limit=l3_memory_limit,
-    )
-
-
-def generate_int4_ab_shapes(
-    hwcfg: dict,
-    l1_memory_limit: int,
-    l3_memory_limit: int,
-) -> Iterable[dict]:
-    return valid_shape_rows(
-        hwcfg,
-        suite="int4_ab",
-        array_shapes=(0, 2),
-        overrides={"int4_a_enable": 1, "int4_b_enable": 1},
-        l1_memory_limit=l1_memory_limit,
-        l3_memory_limit=l3_memory_limit,
-    )
-
-
 def remap_suite_rows(
     hwcfg: dict,
     rows: Iterable[dict],
@@ -266,67 +241,55 @@ def remap_suite_rows(
             }
 
 
-def generate_quantized_shapes(
+def generate_precision_suite(
     hwcfg: dict,
+    name: str,
     l1_memory_limit: int,
     l3_memory_limit: int,
 ) -> Iterable[dict]:
-    base_rows = valid_shape_rows(
-        hwcfg,
-        suite="base_int8",
-        array_shapes=(0, 1, 2),
-        l1_memory_limit=l1_memory_limit,
-        l3_memory_limit=l3_memory_limit,
-    )
-    return remap_suite_rows(
-        hwcfg,
-        base_rows,
-        suite="quantized",
-        overrides={"quantization_enable": 1},
-        l1_memory_limit=l1_memory_limit,
-        l3_memory_limit=l3_memory_limit,
-    )
-
-
-def generate_int32_to_fp16_shapes(
-    hwcfg: dict,
-    l1_memory_limit: int,
-    l3_memory_limit: int,
-) -> Iterable[dict]:
-    int4_b_rows = valid_shape_rows(
-        hwcfg,
-        suite="int4_b",
-        array_shapes=(0, 1, 2),
-        overrides={"int4_b_enable": 1},
-        l1_memory_limit=l1_memory_limit,
-        l3_memory_limit=l3_memory_limit,
-    )
-    return remap_suite_rows(
-        hwcfg,
-        int4_b_rows,
-        suite="int4_b_int32_to_fp16",
-        overrides={"int32tofp16_enable": 1},
-        l1_memory_limit=l1_memory_limit,
-        l3_memory_limit=l3_memory_limit,
-    )
+    """Yield the workload rows for one GEMM_PRECISIONS suite."""
+    spec = GEMM_PRECISIONS[name]
+    if spec["derive_from"] is None:
+        yield from valid_shape_rows(
+            hwcfg,
+            suite=name,
+            array_shapes=spec["array_shapes"],
+            overrides=spec["overrides"],
+            l1_memory_limit=l1_memory_limit,
+            l3_memory_limit=l3_memory_limit,
+        )
+    else:
+        base = GEMM_PRECISIONS[spec["derive_from"]]
+        base_rows = valid_shape_rows(
+            hwcfg,
+            suite=spec["derive_from"],
+            array_shapes=base["array_shapes"],
+            overrides=base["overrides"],
+            l1_memory_limit=l1_memory_limit,
+            l3_memory_limit=l3_memory_limit,
+        )
+        yield from remap_suite_rows(
+            hwcfg,
+            base_rows,
+            suite=name,
+            overrides=spec["overrides"],
+            l1_memory_limit=l1_memory_limit,
+            l3_memory_limit=l3_memory_limit,
+        )
 
 
 def iter_workloads(
     hwcfg: dict,
     *,
+    suites: Optional[Sequence[str]] = None,
     l1_memory_limit: int = L1_MEMORY_LIMIT_BYTES,
     l3_memory_limit: int = L3_MEMORY_LIMIT_BYTES,
 ) -> Iterator[dict]:
     seen = set()
-    suites = (
-        generate_base_int8_shapes,
-        # generate_int4_b_shapes,
-        # generate_int4_ab_shapes,
-        # generate_quantized_shapes,
-        # generate_int32_to_fp16_shapes,
-    )
-    for suite in suites:
-        for row in suite(hwcfg, l1_memory_limit, l3_memory_limit):
+    # Default: sweep every precision in the contract (co-design needs them all).
+    suite_names = list(suites) if suites is not None else list(GEMM_PRECISIONS)
+    for name in suite_names:
+        for row in generate_precision_suite(hwcfg, name, l1_memory_limit, l3_memory_limit):
             key = tuple(row[field] for field in PARAM_FIELDS)
             if key in seen:
                 continue
@@ -337,6 +300,7 @@ def iter_workloads(
 def sample_workloads(
     hwcfg: dict,
     *,
+    suites: Optional[Sequence[str]] = None,
     l1_memory_limit: int,
     l3_memory_limit: int,
     max_cases: int,
@@ -348,6 +312,7 @@ def sample_workloads(
 
     for row in iter_workloads(
         hwcfg,
+        suites=suites,
         l1_memory_limit=l1_memory_limit,
         l3_memory_limit=l3_memory_limit,
     ):
@@ -388,6 +353,13 @@ def parse_args() -> argparse.Namespace:
         help="Randomly sample at most this many rows. Zero means no cap.",
     )
     parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument(
+        "--suites",
+        nargs="*",
+        choices=list(GEMM_PRECISIONS),
+        default=None,
+        help="Precision suites to generate (default: all in GEMM_PRECISIONS).",
+    )
     return parser.parse_args()
 
 
@@ -398,6 +370,7 @@ def main() -> None:
     if args.max_cases:
         rows, total = sample_workloads(
             hwcfg,
+            suites=args.suites,
             l1_memory_limit=args.l1_memory_limit,
             l3_memory_limit=args.l3_memory_limit,
             max_cases=args.max_cases,
@@ -409,6 +382,7 @@ def main() -> None:
         count = write_csv(
             iter_workloads(
                 hwcfg,
+                suites=args.suites,
                 l1_memory_limit=args.l1_memory_limit,
                 l3_memory_limit=args.l3_memory_limit,
             ),

--- a/target/sim/automation/sweep/versacore/versacore_params.py
+++ b/target/sim/automation/sweep/versacore/versacore_params.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""Single source of truth for the VersaCore GEMM test parameter schema.
+
+``testing_workload_gen.py`` (which writes the workload CSV) and
+``testing_launch.py`` (which reads it back to launch each test) must agree on the
+exact ``params.hjson`` field order. Defining it once here keeps the writer and
+reader from drifting; both derive their CSV column lists from this.
+"""
+
+PARAM_FIELDS = [
+    "num_clusters",
+    "array_shape",
+    "data_type",
+    "transposed_A",
+    "transposed_B",
+    "int4_a_enable",
+    "int4_b_enable",
+    "K",
+    "N",
+    "M",
+    "addNonZeroC",
+    "addZeroC",
+    "accumPrevC",
+    "quantization_enable",
+    "int32tofp16_enable",
+]

--- a/target/sw/device/apps/snax/snax-bingo-offload/libsnaxkernel/offload_hw_kernels/gemm.h
+++ b/target/sw/device/apps/snax/snax-bingo-offload/libsnaxkernel/offload_hw_kernels/gemm.h
@@ -29,46 +29,122 @@
 // =============================================================
 // Core-level GEMM kernels (bingo-hw)
 // =============================================================
+//
+// -------------------------------------------------------------
+// Precision support & how to configure it
+// -------------------------------------------------------------
+// The MAC datatype is fixed by the hardware build (this is the int8
+// `snax_versacore_to_cluster` config): the VersaCore array multiplies
+// INT8 x INT8 and accumulates into an INT32 C/D. Element widths come from
+// gemm_shapes.h: BINGO_A_ELEM_LEN = BINGO_B_ELEM_LEN = 8,
+// BINGO_C_ELEM_LEN = BINGO_D32_ELEM_LEN = 32. Changing the *MAC* datatype
+// (e.g. FP8/FP16 multiply) needs a different RTL build (e.g. the FP8
+// `snax_versacore_dse_cluster`) and cannot be selected at runtime here.
+//
+// On this int8 build, precision is selected per call via the
+// __snax_bingo_kernel_gemm_full_args_t fields below (no rebuild needed); they
+// flow host -> device as: params.hjson -> the workload datagen -> these kernel
+// args. The flags only change operand packing and the output stage:
+//   - int4_a_enable / int4_b_enable : pack operand A / B to 4-bit
+//       (a_elem_len / b_elem_len 8 -> 4). Inputs only; the MAC still runs on
+//       the int8 array. The A/B channel-enable masks are rebuilt dynamically.
+//   - quantization_enable (+ shift_i, multiplier_i, input_zp_i, output_zp_i):
+//       requantize the INT32 accumulator down to an INT8 output
+//       (d_elem_len 32 -> 8).
+//   - int32tofp16_enable : convert the INT32 accumulator to an FP16 output
+//       (d_elem_len 32 -> 16).
+//   - none set : INT32 output (d_elem_len = 32, the baseline).
+// quantization_enable and int32tofp16_enable are mutually exclusive (the only
+// two output-stage extensions); both set -> BINGO_RET_FAIL.
+//
+// The 6 reachable precision modes (input_A x input_B -> output_D), i.e. the
+// GEMM_PRECISIONS suites in
+// target/sim/automation/sweep/versacore/testing_workload_gen.py. Each has a
+// clean precision-named wrapper kernel below (preferred); gemm_full stays the
+// low-level escape hatch that exposes all flags:
+//   int8 x int8 -> int32   (all flags 0)                    -> gemm_i8i8_i32
+//   int8 x int4 -> int32   (int4_b_enable)                  -> gemm_i8i4_i32
+//   int4 x int4 -> int32   (int4_a_enable + int4_b_enable)  -> gemm_i4i4_i32
+//   int8 x int8 -> int8    (quantization_enable + requant)  -> gemm_i8i8_i8
+//   int8 x int4 -> fp16    (int4_b_enable + int32tofp16)    -> gemm_i8i4_f16
+//   int8 x int8 -> fp16    (int32tofp16)                    -> gemm_i8i8_f16
+// (B is the weight operand; int4_b packs B to 4-bit.)
+// -------------------------------------------------------------
 
-SNAX_LIB_DEFINE uint32_t __snax_bingo_kernel_gemm_full(void *arg)
+// -------------------------------------------------------------
+// The "+C" term and accumPrevC  (D = A*B + C)
+// -------------------------------------------------------------
+// Every GEMM here computes D = A*B + C. The accumPrevC flag selects WHERE the
+// "+C" addend comes from: a C operand in memory, or the value already sitting
+// in the VersaCore accumulator register from the previous compute. There are
+// three mutually-exclusive C-handling modes (the host datagen asserts exactly
+// one is active):
+//
+//   1. add a real C (accumPrevC=0, C_addr != 0)  -> D = A*B + C_mem
+//        C is streamed from L1 using the shape's channel_en_C mask.
+//        Internally addNonZeroC=1 is inferred below.
+//   2. add zero  (accumPrevC=0, C_addr == 0)      -> D = A*B
+//        C is forced to 0: the C reader uses bingo_channel_en_C_null, so the
+//        accumulator is seeded with the bare product. addNonZeroC=0.
+//   3. accumulate previous (accumPrevC=1)         -> D = A*B + prev_reg
+//        NO C is streamed (Ctlbound0=0, channel_en_C_null). The array adds the
+//        new product on top of whatever its accumulator register still holds
+//        from the prior kernel call. addNonZeroC=0.
+//
+// How it reaches the hardware:
+//   set_versacore_csr(accumPrevC == 0, ...) writes the OVERWRITE_ACCUM CSR =
+//   take_in_new_c. In the array (chisel_acc .../versacore/{VersaCore,Accumulator,
+//   Array}.scala) this drives accAddExtIn, which is asserted only on the FIRST
+//   of the K accumulation steps of each output tile:
+//     accAddExtIn = (computeFireCounter==0) && take_in_new_c && busy
+//   On that first step the accumulator register is initialized to:
+//     take_in_new_c=1 (accumPrevC=0): reg := product[0] + C_external  (fresh: C or 0)
+//     take_in_new_c=0 (accumPrevC=1): reg := product[0] + reg_old     (keeps prior sum)
+//   Steps 1..K-1 always do reg += product[k] (the normal K reduction). The
+//   register is NOT cleared between kernel calls, which is exactly what lets a
+//   later accumPrevC=1 call continue a sum left by an earlier call.
+//
+// CONSTRAINT: accumPrevC=1 requires M == 1 && N == 1. The accumulator register
+// holds only ONE output tile (meshRow x meshCol). With M>1 or N>1 the array
+// walks to other tiles and overwrites the register, so "previous C" is only
+// well-defined for a single tile. (The host datagen asserts M==N==1 here.)
+//
+// Worked example — on-chip K-split / chained accumulation of one output tile,
+// computing  D = A0*B0 + A1*B1 + A2*B2  without ever loading/storing a partial
+// C to L1 between passes (M=N=1, same D_addr each call):
+//
+//   // pass 0: seed the register with A0*B0 (no C, accumPrevC=0)
+//   gemm(A0,B0, C=0,    D, M=1,K,N=1, accumPrevC=0); // reg = A0*B0,           D=reg
+//   // pass 1: add A1*B1 onto the kept register (accumPrevC=1, C ignored)
+//   gemm(A1,B1, C=0/ign,D, M=1,K,N=1, accumPrevC=1); // reg = A0*B0+A1*B1,     D=reg
+//   // pass 2: add A2*B2 onto the kept register
+//   gemm(A2,B2, C=0/ign,D, M=1,K,N=1, accumPrevC=1); // reg = A0*B0+A1*B1+A2*B2,D=reg
+//
+// After pass 2, D holds the full sum. Versus mode 1, this saves the C-load +
+// C-store memory traffic on every pass by keeping the running sum on-chip.
+// (To instead seed pass 0 with a bias term, use accumPrevC=0 with C_addr != 0.)
+// -------------------------------------------------------------
+
+// -------------------------------------------------------------
+// Shared GEMM core: configure the streamer + VersaCore and run.
+// All precision/quant fields are explicit parameters so the precision-named
+// wrappers (and gemm_full) below select them; the body is unchanged from the
+// original gemm_full. Emits the shared GEMM_FULL_RUN trace markers for every
+// caller, so the sweep/gemm cycle LUT works for all precisions.
+// Caller must already have done the core-0 check + SW guard + arg parse.
+// -------------------------------------------------------------
+static uint32_t __bingo_gemm_run(
+    uint32_t A_addr, uint32_t B_addr, uint32_t C_addr, uint32_t D_addr,
+    uint32_t M, uint32_t K, uint32_t N, uint32_t array_shape_idx,
+    uint32_t transpose_A, uint32_t transpose_B, uint32_t accumPrevC,
+    uint32_t quantization_enable, uint32_t shift_i, uint32_t multiplier_i,
+    int32_t input_zp_i, int32_t output_zp_i, int32_t int32tofp16_enable,
+    int32_t int4_a_enable, int32_t int4_b_enable,
+    bingo_kernel_scratchpad_t *sp)
 {
-    BINGO_SW_GUARD_CHECK(arg, __snax_bingo_kernel_gemm_full_args_t);
-    // Assume the matrix data are all in L1
-    // So all the addr are 32bit local addr
-    // This kernel will configure the versacore and streamer and start the computation
-    // There is another __snax_bingo_kernel_gemm_minimal kernel that only starts the versacore and streamer with pre-configured CSRs
-    if (snrt_cluster_core_idx() != 0)
-    {
-        printf_safe("[Cluster %d Core %d]: Error! Bingo GEMM full should be called from core 0!\r\n", snrt_cluster_idx(), snrt_cluster_core_idx());
-        return BINGO_RET_FAIL;
-    }
-    BINGO_TRACE_MARKER(BINGO_TRACE_KERNEL_ARG_PARSE_START);
-    const __snax_bingo_kernel_gemm_full_args_t *args =
-        (const __snax_bingo_kernel_gemm_full_args_t *)arg;
-    uint32_t A_addr = args->input_A_addr;
-    uint32_t B_addr = args->input_B_addr;
-    uint32_t C_addr = args->input_C_addr;
-    uint32_t D_addr = args->output_D_addr;
-    VERSACORE_DEBUG_PRINT("[Cluster %d Core %d]: Bingo GEMM Full called with A_addr=0x%08x, B_addr=0x%08x, C_addr=0x%08x, D_addr=0x%08x\r\n",
+    VERSACORE_DEBUG_PRINT("[Cluster %d Core %d]: Bingo GEMM run A=0x%08x B=0x%08x C=0x%08x D=0x%08x\r\n",
                           snrt_cluster_idx(), snrt_cluster_core_idx(),
                           A_addr, B_addr, C_addr, D_addr);
-    uint32_t M = args->M;
-    uint32_t K = args->K;
-    uint32_t N = args->N;
-    uint32_t array_shape_idx = args->array_shape_idx;
-    uint32_t transpose_A = args->transpose_A;
-    uint32_t transpose_B = args->transpose_B;
-    uint32_t accumPrevC = args->accumPrevC;
-    uint32_t quantization_enable = args->quantization_enable;
-    uint32_t shift_i = args->shift_i;
-    uint32_t multiplier_i = args->multiplier_i;
-    int32_t input_zp_i = args->input_zp_i;
-    int32_t output_zp_i = args->output_zp_i;
-    int32_t int32tofp16_enable = args->int32tofp16_enable;
-    int32_t int4_a_enable = args->int4_a_enable;
-    int32_t int4_b_enable = args->int4_b_enable;
-    bingo_kernel_scratchpad_t *sp = BINGO_GET_SP(arg, __snax_bingo_kernel_gemm_full_args_t);
-    BINGO_TRACE_MARKER(BINGO_TRACE_KERNEL_ARG_PARSE_END);
     BINGO_TRACE_MARKER(BINGO_TRACE_GEMM_FULL_CFG_START);
     // Bounds-check array_shape_idx against the hwcfg, then grab the per-shape
     // parameter block. All shape-dependent values are read from `shape` below
@@ -199,12 +275,29 @@ SNAX_LIB_DEFINE uint32_t __snax_bingo_kernel_gemm_full(void *arg)
     // Atlbound5
     Atlbound[5] = 1;
     uint32_t Atlstride[6];
-    // Atlstride0
-    Atlstride[0] = a_elem_len * meshRow * tileSize / 8;
+    // Atlstride0 — A K-tile pitch in bytes. The A reader's sparse interconnect
+    // wires read-port i only to banks of parity (i % BINGO_GRANULARITY_A), so
+    // the K-tile stride (in banks) must be a multiple of BINGO_GRANULARITY_A or
+    // a later K step walks port 0 onto an odd bank (unroutable -> fatal). For
+    // int8 A the tile is already an even number of banks for every shape; for
+    // int4 A at array_shape 1 the tile is a single bank, so round the pitch UP
+    // to BINGO_GRANULARITY_A banks. The datagen pads each int4 A K-tile to the
+    // same width (gemm_sim_utils.py), so the pad bytes land in the skipped bank
+    // and the VersaCore still consumes the valid tile (channel_en is unchanged).
+    uint32_t a_tile_banks =
+        (a_elem_len * meshRow * tileSize + BINGO_BANK_WIDTH - 1) / BINGO_BANK_WIDTH;
+    if (a_tile_banks == 0)
+    {
+        a_tile_banks = 1;
+    }
+    uint32_t a_tile_banks_aligned =
+        ((a_tile_banks + BINGO_GRANULARITY_A - 1) / BINGO_GRANULARITY_A) *
+        BINGO_GRANULARITY_A;
+    Atlstride[0] = a_tile_banks_aligned * (BINGO_BANK_WIDTH / 8);
     // Atlstride1
     Atlstride[1] = 0;
-    // Atlstride2
-    Atlstride[2] = a_elem_len * meshRow * tileSize * K / 8;
+    // Atlstride2 — one full K-run, using the (granularity-aligned) K-tile pitch.
+    Atlstride[2] = Atlstride[0] * K;
     // Atlstride3
     Atlstride[3] = 0;
     // Atlstride4
@@ -307,6 +400,15 @@ SNAX_LIB_DEFINE uint32_t __snax_bingo_kernel_gemm_full(void *arg)
                                       snrt_cluster_idx(), snrt_cluster_core_idx());
                 return BINGO_RET_FAIL;
             }
+            // The D-extension output serializer PACKS output_matrix_per_store
+            // narrowed tiles into one BINGO_SERIAL_C_D_WIDTH beat and only emits a
+            // beat once it is full, so M*N must fill whole beats. If it does not
+            // (e.g. array_shape 1 small GEMMs where one narrowed tile <
+            // BINGO_SERIAL_C_D_WIDTH and M*N < output_matrix_per_store) the
+            // serializer would stall waiting for tiles that never come (sim hang).
+            // Bail cleanly; the sweep workload drops these unsupported configs up
+            // front (util/sim/gemm/gemm_psweep_lib.py) so this guard is never hit
+            // there. (Padding M/N to fill a beat would change the measured GEMM.)
             if (((M * N * one_output_tile_bits) % BINGO_SERIAL_C_D_WIDTH) != 0)
             {
                 VERSACORE_DEBUG_PRINT("[Cluster %d Core %d]: Error! D extension output does not fill streamer stores cleanly\r\n",
@@ -413,6 +515,123 @@ SNAX_LIB_DEFINE uint32_t __snax_bingo_kernel_gemm_full(void *arg)
     sp->return_value = D_addr;
     sp->num_return_values = M * N;
     return BINGO_RET_SUCC;
+}
+
+// -------------------------------------------------------------
+// gemm_full: low-level entry point exposing every precision/quant flag.
+// Thin parser over __bingo_gemm_run (behavior identical to the original).
+// -------------------------------------------------------------
+SNAX_LIB_DEFINE uint32_t __snax_bingo_kernel_gemm_full(void *arg)
+{
+    BINGO_SW_GUARD_CHECK(arg, __snax_bingo_kernel_gemm_full_args_t);
+    if (snrt_cluster_core_idx() != 0)
+    {
+        printf_safe("[Cluster %d Core %d]: Error! Bingo GEMM full should be called from core 0!\r\n", snrt_cluster_idx(), snrt_cluster_core_idx());
+        return BINGO_RET_FAIL;
+    }
+    BINGO_TRACE_MARKER(BINGO_TRACE_KERNEL_ARG_PARSE_START);
+    const __snax_bingo_kernel_gemm_full_args_t *a =
+        (const __snax_bingo_kernel_gemm_full_args_t *)arg;
+    bingo_kernel_scratchpad_t *sp = BINGO_GET_SP(arg, __snax_bingo_kernel_gemm_full_args_t);
+    BINGO_TRACE_MARKER(BINGO_TRACE_KERNEL_ARG_PARSE_END);
+    return __bingo_gemm_run(
+        a->input_A_addr, a->input_B_addr, a->input_C_addr, a->output_D_addr,
+        a->M, a->K, a->N, a->array_shape_idx,
+        a->transpose_A, a->transpose_B, a->accumPrevC,
+        a->quantization_enable, a->shift_i, a->multiplier_i,
+        a->input_zp_i, a->output_zp_i, a->int32tofp16_enable,
+        a->int4_a_enable, a->int4_b_enable, sp);
+}
+
+// -------------------------------------------------------------
+// Clean per-precision wrappers (preferred user interface). Each fixes the
+// precision flags; the user passes only operands/shape (the quantized one
+// also takes requant params). All delegate to __bingo_gemm_run, which emits
+// the shared GEMM_FULL_RUN trace markers.
+// -------------------------------------------------------------
+
+// Shared prologue for the "plain" (non-requant) wrappers. NOTE: contains early
+// returns (SW guard + core-0 check), so it must expand inside the kernel body.
+// Declares `a` (args) and `sp` (scratchpad) for the run macro below.
+#define BINGO_GEMM_PLAIN_PROLOGUE()                                                            \
+    BINGO_SW_GUARD_CHECK(arg, __snax_bingo_kernel_gemm_args_t);                                 \
+    if (snrt_cluster_core_idx() != 0)                                                           \
+    {                                                                                          \
+        printf_safe("[Cluster %d Core %d]: Error! Bingo GEMM should be called from core 0!\r\n", \
+                    snrt_cluster_idx(), snrt_cluster_core_idx());                               \
+        return BINGO_RET_FAIL;                                                                  \
+    }                                                                                          \
+    BINGO_TRACE_MARKER(BINGO_TRACE_KERNEL_ARG_PARSE_START);                                     \
+    const __snax_bingo_kernel_gemm_args_t *a =                                                  \
+        (const __snax_bingo_kernel_gemm_args_t *)arg;                                           \
+    bingo_kernel_scratchpad_t *sp = BINGO_GET_SP(arg, __snax_bingo_kernel_gemm_args_t);         \
+    BINGO_TRACE_MARKER(BINGO_TRACE_KERNEL_ARG_PARSE_END)
+
+// __bingo_gemm_run call for a plain wrapper with the given precision flags
+// (no requantization: quant=0, shift/mult/zp=0).
+#define BINGO_GEMM_PLAIN_RUN(int4_a, int4_b, int32tofp16)                                      \
+    __bingo_gemm_run(a->input_A_addr, a->input_B_addr, a->input_C_addr, a->output_D_addr,       \
+                     a->M, a->K, a->N, a->array_shape_idx,                                      \
+                     a->transpose_A, a->transpose_B, a->accumPrevC,                             \
+                     0, 0, 0, 0, 0, (int32tofp16), (int4_a), (int4_b), sp)
+
+// int8 x int8 -> int32 (baseline).
+SNAX_LIB_DEFINE uint32_t __snax_bingo_kernel_gemm_i8i8_i32(void *arg)
+{
+    BINGO_GEMM_PLAIN_PROLOGUE();
+    return BINGO_GEMM_PLAIN_RUN(/*int4_a*/ 0, /*int4_b*/ 0, /*int32tofp16*/ 0);
+}
+
+// int8 x int4 -> int32 (weight operand B packed to 4-bit).
+SNAX_LIB_DEFINE uint32_t __snax_bingo_kernel_gemm_i8i4_i32(void *arg)
+{
+    BINGO_GEMM_PLAIN_PROLOGUE();
+    return BINGO_GEMM_PLAIN_RUN(/*int4_a*/ 0, /*int4_b*/ 1, /*int32tofp16*/ 0);
+}
+
+// int4 x int4 -> int32 (both operands packed to 4-bit).
+SNAX_LIB_DEFINE uint32_t __snax_bingo_kernel_gemm_i4i4_i32(void *arg)
+{
+    BINGO_GEMM_PLAIN_PROLOGUE();
+    return BINGO_GEMM_PLAIN_RUN(/*int4_a*/ 1, /*int4_b*/ 1, /*int32tofp16*/ 0);
+}
+
+// int8 x int4 -> fp16 (weight B int4; int32 accumulator converted to fp16).
+SNAX_LIB_DEFINE uint32_t __snax_bingo_kernel_gemm_i8i4_f16(void *arg)
+{
+    BINGO_GEMM_PLAIN_PROLOGUE();
+    return BINGO_GEMM_PLAIN_RUN(/*int4_a*/ 0, /*int4_b*/ 1, /*int32tofp16*/ 1);
+}
+
+// int8 x int8 -> fp16 (no input packing; int32 accumulator converted to fp16).
+SNAX_LIB_DEFINE uint32_t __snax_bingo_kernel_gemm_i8i8_f16(void *arg)
+{
+    BINGO_GEMM_PLAIN_PROLOGUE();
+    return BINGO_GEMM_PLAIN_RUN(/*int4_a*/ 0, /*int4_b*/ 0, /*int32tofp16*/ 1);
+}
+
+// int8 x int8 -> int8 (int32 accumulator requantized to int8). Takes the
+// requant params (shift/multiplier/zero-points) in its dedicated args struct.
+SNAX_LIB_DEFINE uint32_t __snax_bingo_kernel_gemm_i8i8_i8(void *arg)
+{
+    BINGO_SW_GUARD_CHECK(arg, __snax_bingo_kernel_gemm_quant_args_t);
+    if (snrt_cluster_core_idx() != 0)
+    {
+        printf_safe("[Cluster %d Core %d]: Error! Bingo GEMM should be called from core 0!\r\n",
+                    snrt_cluster_idx(), snrt_cluster_core_idx());
+        return BINGO_RET_FAIL;
+    }
+    BINGO_TRACE_MARKER(BINGO_TRACE_KERNEL_ARG_PARSE_START);
+    const __snax_bingo_kernel_gemm_quant_args_t *a =
+        (const __snax_bingo_kernel_gemm_quant_args_t *)arg;
+    bingo_kernel_scratchpad_t *sp = BINGO_GET_SP(arg, __snax_bingo_kernel_gemm_quant_args_t);
+    BINGO_TRACE_MARKER(BINGO_TRACE_KERNEL_ARG_PARSE_END);
+    return __bingo_gemm_run(
+        a->input_A_addr, a->input_B_addr, a->input_C_addr, a->output_D_addr,
+        a->M, a->K, a->N, a->array_shape_idx,
+        a->transpose_A, a->transpose_B, a->accumPrevC,
+        /*quant*/ 1, a->shift_i, a->multiplier_i, a->input_zp_i, a->output_zp_i,
+        /*int32tofp16*/ 0, /*int4_a*/ 0, /*int4_b*/ 0, sp);
 }
 
 SNAX_LIB_DEFINE uint32_t __snax_bingo_kernel_gemm_minimal(void *arg)

--- a/target/sw/device/apps/snax/snax-bingo-offload/libsnaxkernel/snax_kernel_lib.h
+++ b/target/sw/device/apps/snax/snax-bingo-offload/libsnaxkernel/snax_kernel_lib.h
@@ -61,6 +61,13 @@ SNAX_SYMTAB_SECTION const snax_symbol_t __snax_symtab[] = {
     SNAX_EXPORT_FUNC(__snax_bingo_kernel_idma_1d_copy),
     SNAX_EXPORT_FUNC(__snax_bingo_kernel_idma_broadcast),
     SNAX_EXPORT_FUNC(__snax_bingo_kernel_gemm_full),
+    // Clean per-precision GEMM wrappers (over gemm_full) — see offload_hw_kernels/gemm.h.
+    SNAX_EXPORT_FUNC(__snax_bingo_kernel_gemm_i8i8_i32),
+    SNAX_EXPORT_FUNC(__snax_bingo_kernel_gemm_i8i4_i32),
+    SNAX_EXPORT_FUNC(__snax_bingo_kernel_gemm_i4i4_i32),
+    SNAX_EXPORT_FUNC(__snax_bingo_kernel_gemm_i8i8_i8),
+    SNAX_EXPORT_FUNC(__snax_bingo_kernel_gemm_i8i4_f16),
+    SNAX_EXPORT_FUNC(__snax_bingo_kernel_gemm_i8i8_f16),
     SNAX_EXPORT_FUNC(__snax_bingo_kernel_gemm_minimal),
     SNAX_EXPORT_FUNC(__snax_bingo_kernel_xdma_1d_copy),
     SNAX_EXPORT_FUNC(__snax_bingo_kernel_xdma_6d),

--- a/target/sw/device/runtime/snax/versacore/gemm_shapes.h
+++ b/target/sw/device/runtime/snax/versacore/gemm_shapes.h
@@ -50,6 +50,14 @@
 #define BINGO_D32_ELEM_LEN        32
 #define BINGO_SERIAL_C_D_WIDTH    1024
 
+// A-reader sparse-interconnect access granularity, in banks — must match the
+// hwcfg snax_acc_cfg `granularity_a` in snax_versacore_to_cluster.hjson. The A
+// reader's sparse TCDM crossbar wires read-port i only to banks of parity
+// (i % BINGO_GRANULARITY_A), so each A-reader K-tile stride must be a multiple
+// of this many banks (else a later K step walks port 0 onto an odd bank, which
+// is physically unroutable -> SparseInterconnect "Illegal bank access" fatal).
+#define BINGO_GRANULARITY_A       2
+
 // Per-stream CSR counts (how many uint32 words each channel-enable mask
 // spans). Derived from the hwcfg's array-width fields.
 #define BINGO_A_CSR_NUM           1

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/Makefile
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/Makefile
@@ -35,6 +35,7 @@ APPS += basic_quantize_host
 APPS += basic_dequantize_host
 APPS += basic_int32_add_host
 APPS += gemm_ksplit_4cluster
+APPS += gemm_nsplit_accumprevc_4cluster
 APPS += basic_softmax_host
 APPS += attn_reference_4cluster
 APPS += device_host_idma_check_1cluster

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_nsplit_accumprevc_4cluster/.gitignore
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_nsplit_accumprevc_4cluster/.gitignore
@@ -1,0 +1,6 @@
+nsplit_accumprevc_gemm_data.h
+offload_bingo_hw.h
+*.png
+*.csv
+__pycache__/
+build/

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_nsplit_accumprevc_4cluster/Makefile
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_nsplit_accumprevc_4cluster/Makefile
@@ -1,0 +1,53 @@
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fanchen Kong <fanchen.kong@kuleuven.be>
+#
+# Design-C GEMM: N-parallel across 4 clusters + on-chip K-accumulation via accumPrevC
+# (no host reduction). Data is embedded as C arrays (no mem chip), so this needs
+# no --systemcfg.
+MK_DIR   := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+HOST_APP_TYPE = offload_bingo_hw
+CHIP_TYPE     = single_chip
+WORKLOAD      = gemm_nsplit_accumprevc_4cluster
+DEV_APP       = snax-bingo-offload
+SRCS = ../../src/offload_bingo_hw.c
+BINGO_HOST ?= 1
+INCL_DEVICE_BINARY ?= 1
+
+DATA_CFG ?= $(MK_DIR)/params.hjson
+DATA_H = $(MK_DIR)/nsplit_accumprevc_gemm_data.h
+OFFLOAD_H = $(MK_DIR)/offload_bingo_hw.h
+BENDER   = bender
+SNITCH_ROOT = $(shell $(BENDER) path snitch_cluster)
+PLATFORM_H = $(MK_DIR)/../../../../../../../../target/sw/shared/platform/generated/occamy.h
+
+$(DATA_H) $(OFFLOAD_H): $(MK_DIR)/main_bingo.py $(MK_DIR)/nsplit_accumprevc_gemm_datagen.py $(DATA_CFG)
+	python3 $(MK_DIR)/main_bingo.py \
+		--output_dir $(MK_DIR) \
+		--data_h $(DATA_H) \
+		-c $(DATA_CFG) \
+		--hwcfg $(SNITCH_ROOT)/target/snitch_cluster/cfg/snax_versacore_to_cluster.hjson \
+		--platformcfg $(PLATFORM_H)
+
+INCDIRS += $(MK_DIR)
+PARTIAL_OUTPUTS += $(DATA_H)
+PARTIAL_OUTPUTS += $(OFFLOAD_H)
+
+.PHONY: clean-data clean-offload clean
+clean-data:
+	rm -f $(DATA_H)
+clean-offload:
+	rm -rf $(OFFLOAD_H)
+	rm -rf *.png
+	rm -rf *.csv
+clean: clean-data clean-offload
+gen-data: $(DATA_H)
+gen-offload: $(OFFLOAD_H)
+
+include ../../../../common.mk
+
+# offload_bingo_hw.c includes the generated workload header.  Parent builds can
+# target the final ELF directly, so ensure dependency generation creates it first.
+$(DEP): $(OFFLOAD_H) $(DATA_H)

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_nsplit_accumprevc_4cluster/main_bingo.py
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_nsplit_accumprevc_4cluster/main_bingo.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+r"""
+gemm_nsplit_accumprevc_4cluster
+
+Parallelize a GEMM along N across the 4 clusters (each owns one disjoint output
+tile) and do the K reduction ON-CHIP inside each cluster with the VersaCore
+`accumPrevC` feature -- so the host core never sums anything. Contrast
+gemm_ksplit_4cluster, which computes parallel K-partials and then reduces them
+with a serial host int32_add chain.
+
+Why accumPrevC works here (and not across a parallel K-split): the accumulator
+register is private to ONE cluster's VersaCore and is never cleared at kernel
+end (Accumulator.scala: it only updates on adder.out.fire). Two GEMM nodes placed
+on the same cluster's GEMM core run strictly back-to-back -- bingo_dfg.py's
+bingo_transform_add_core_sequencing_edges groups nodes by (chiplet,cluster,core)
+and serializes them -- so the second call (accumPrevC=1) accumulates onto the
+register the first call (accumPrevC=0) left behind. `input_C_addr=0` on every
+call: with accumPrevC no C is streamed (the "+C" comes from the register).
+
+Constraint: accumPrevC needs M=1 and N=1 per call (the register is one tile), so
+each cluster owns exactly one output tile and N_global = num_clusters.
+
+================================================================================
+WHO HOLDS WHAT  --  the GEMM is split along N; each cluster owns ONE output tile.
+
+  Global GEMM (tile counts M=1, K=k_chunks, N=num_clusters):   D = A . B
+
+  A is SHARED by every cluster (M=1 row-tile), split over K into chunks:
+        A = [ A_k0 | A_k1 | ... ]            (one meshRow x tileSize tile per chunk)
+
+  B is split by N (one column-block per cluster), each block also split over K:
+                 cluster0    cluster1    cluster2    cluster3
+               +----------+----------+----------+----------+
+        chunk0 |  B0_k0   |  B1_k0   |  B2_k0   |  B3_k0   |
+        chunk1 |  B0_k1   |  B1_k1   |  B2_k1   |  B3_k1   |
+               +----------+----------+----------+----------+
+
+  D is those tiles laid side by side along N  --  NO host reduction:
+               +----------+----------+----------+----------+
+         D  =  |    D0    |    D1    |    D2    |    D3    |
+               | cluster0 | cluster1 | cluster2 | cluster3 |
+               +----------+----------+----------+----------+
+                 \____________ concatenation, no add node ____________/
+
+  Each cluster c builds its OWN tile by accumulating over K on-chip:
+        Dc = A_k0 . Bc_k0  +  A_k1 . Bc_k1  + ...
+             |__ Gemm k0 __|  |__ Gemm k1 (accumPrevC=1) __|
+              reg = P0          reg += P1  ->  reg = Dc   (register kept call-to-call)
+
+================================================================================
+NUMERICAL WALKTHROUGH  (logical 2x2 tiles so it fits; the real workload uses mesh
+32x2x32, M=1, N=4, K=2).  Worked for cluster 0; clusters 1-3 are identical with
+their own B column-block.
+
+  Shared A (2 rows x 4 cols) and its two K-chunks:
+        A    = [ 1  2 | 3  4 ]       A_k0 = [ 1  2 ]      A_k1 = [ 3  4 ]
+               [ 5  6 | 7  8 ]              [ 5  6 ]             [ 7  8 ]
+
+  Cluster 0's B column-block (4 rows x 2 cols) and its two K-chunks:
+        B0   = [ 1  0 ]              B0_k0 = [ 1  0 ]     B0_k1 = [ 2  1 ]
+               [ 0  1 ]                      [ 0  1 ]             [ 1  2 ]
+               [ 2  1 ]
+               [ 1  2 ]
+
+  Gemm k0 (accumPrevC=0):  reg = A_k0 . B0_k0 = [  1   2 ]  = P0
+                                                [  5   6 ]
+  Gemm k1 (accumPrevC=1):  P1  = A_k1 . B0_k1 = [ 10  11 ]
+                                                [ 22  23 ]
+                           reg = P0 + P1       = [ 11  13 ]  = D0   (cluster 0's tile)
+                                                [ 27  29 ]
+
+  Assembled D  --  each cluster's 2x2 tile sits in the N-band it owns:
+                cluster0    cluster1    cluster2    cluster3
+              +----------+----------+----------+----------+
+         D =  | 11    13 |  D1[0,:] |  D2[0,:] |  D3[0,:] |
+              | 27    29 |  D1[1,:] |  D2[1,:] |  D3[1,:] |
+              +----------+----------+----------+----------+
+                ^ computed entirely on cluster 0, no other cluster touches it
+
+================================================================================
+Per-cluster DFG (cluster c; DOUBLE-BUFFERED: one A/B buffer per K-chunk, k_chunks=2):
+
+  Load_A_c{c}_k0 \                              Load_A_c{c}_k1 \
+                  Gemm_c{c}_k0 ---------------->                Gemm_c{c}_k1 -> Store -> Check
+  Load_B_c{c}_k0 /  (accumPrevC=0, C=0)         Load_B_c{c}_k1 /  (accumPrevC=1, C=0)
+                    reg = A0*Bc0                                  reg += A1*Bc1 = Dc
+
+  Chunk 1's loads write their OWN buffers, so they do NOT wait on Gemm k0 (no WAR
+  edge): the DMA core prefetches chunk 1 while the GEMM core runs chunk 0. The
+  only ordering kept is Gemm k0 -> Gemm k1 -- the accumPrevC register must survive
+  between the two calls.
+
+--------------------------------------------------------------------------------
+Gantt (all 4 clusters in parallel; DOUBLE-BUFFERED => NO GEMM bubble: the chunk-1
+load overlaps Gemm k0, so Gemm k0 and Gemm k1 run back-to-back). DMA core = loads
++ store, GEMM core = matmul, HOST = checks:
+
+  time ->   t0      t1      t2       t3       t4        t5
+  DMA c0:  LdA k0  LdB k0  LdA k1   LdB k1            Store D0
+  GEMM c0:                 Gemm k0  Gemm k1                       reg: 0->P0->P0+P1=D0
+  DMA c1:  LdA k0  LdB k0  LdA k1   LdB k1            Store D1
+  GEMM c1:                 Gemm k0  Gemm k1
+  DMA c2:  LdA k0  LdB k0  LdA k1   LdB k1            Store D2
+  GEMM c2:                 Gemm k0  Gemm k1
+  DMA c3:  LdA k0  LdB k0  LdA k1   LdB k1            Store D3
+  GEMM c3:                 Gemm k0  Gemm k1
+  HOST:                                              Check D0|D1|D2|D3
+
+  LdA/LdB k1 land in the chunk-1 buffers DURING Gemm k0, so the moment Gemm k0
+  retires, Gemm k1 starts -- the bubble between the two GEMMs (present with a
+  single reused buffer) is gone. Still no host-reduction row: D = [D0|D1|D2|D3].
+"""
+
+import os
+import sys
+import argparse
+import pathlib
+import hjson
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+WORKLOADS_DIR = os.path.dirname(current_dir)
+sys.path.append(WORKLOADS_DIR)
+ROOT_DIR = os.path.abspath(os.path.join(current_dir, "../../../../../../../../"))
+ROOT_DIR = os.path.normpath(ROOT_DIR)
+
+sys.path.append(f"{ROOT_DIR}/target/sw/host/runtime/libbingo/mini_compiler")
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from nsplit_accumprevc_gemm_datagen import emit_header_file  # noqa E402
+from bingo_dfg import BingoDFG  # noqa E402
+from bingo_platform import guard_cluster_count, parse_platform_cfg  # noqa E402
+from bingo_node import BingoNode  # noqa E402
+from bingo_mem_handle import BingoMemAlloc, BingoMemSymbol  # noqa E402
+from bingo_kernel_args import (  # noqa E402
+    SnaxBingoKernelIdma1dCopyArgs,
+    SnaxBingoKernelGemmFullArgs,
+    HostBingoKernelCheckResultArgs,
+)
+
+DATA_HEADER = "nsplit_accumprevc_gemm_data.h"
+
+# Core assignment within a cluster (matches the other offload_bingo_hw workloads)
+GEMM_CORE = 0
+DMA_CORE = 1
+HOST_CORE = 2
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="gemm_nsplit_accumprevc_4cluster")
+    parser.add_argument("--output_dir", type=str, default=".")
+    parser.add_argument("--output_offload_file_name", type=str, default="offload_bingo_hw.h")
+    parser.add_argument("-c", "--cfg", type=pathlib.Path, required=True)
+    parser.add_argument("--hwcfg", type=pathlib.Path, required=True)
+    parser.add_argument("--platformcfg", type=pathlib.Path, required=True)
+    parser.add_argument("--data_h", type=pathlib.Path, default=None)
+    return parser.parse_args()
+
+
+def main():
+    args = get_args()
+    output_dir = args.output_dir
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    with open(args.cfg) as f:
+        param = hjson.loads(f.read())
+    with open(args.hwcfg) as f:
+        hw = hjson.loads(f.read())
+    merged = {**param, **hw}
+
+    # Emit the data header (embedded C arrays).
+    if args.data_h is not None:
+        with open(args.data_h, "w") as f:
+            f.write(emit_header_file(**merged))
+        print(f"Written data header: {args.data_h}")
+
+    # Derive params.
+    array_shape = merged["array_shape"]
+    data_type = merged.get("data_type", 0)
+    num_clusters = merged["num_clusters"]
+    M = merged["M"]
+    N_per_cluster = merged["N_per_cluster"]
+    k_chunks = merged["k_chunks"]
+    K_per_chunk = merged["K_per_chunk"]
+    transpose_A = merged.get("transposed_A", 0)
+    transpose_B = merged.get("transposed_B", 0)
+
+    if M != 1 or N_per_cluster != 1:
+        raise ValueError(f"accumPrevC needs M==1 and N_per_cluster==1, got M={M} N_per_cluster={N_per_cluster}")
+
+    snax_acc_cfg = merged["snax_versacore_core_template"]["snax_acc_cfg"][0]
+    meshRow, tileSize, meshCol = snax_acc_cfg["snax_versacore_spatial_unrolling"][data_type][array_shape]
+
+    # Byte sizes of the per-call operands (int8 inputs, int32 output tile).
+    A_chunk_bytes = M * K_per_chunk * meshRow * tileSize          # int8
+    B_chunk_bytes = K_per_chunk * N_per_cluster * tileSize * meshCol  # int8
+    D_bytes = M * N_per_cluster * meshRow * meshCol * 4           # int32
+
+    # Platform.
+    platform = parse_platform_cfg(args.platformcfg)
+    if not guard_cluster_count(param, platform, args.output_dir, args.output_offload_file_name):
+        return
+
+    dfg = BingoDFG(
+        num_chiplets=platform["num_chiplets"],
+        num_clusters_per_chiplet=platform["num_clusters_per_chiplet"],
+        num_cores_per_cluster=platform["num_cores_per_cluster"],
+        is_host_as_acc=True,
+        chiplet_ids=platform["chiplet_ids"],
+    )
+
+    # Embedded-symbol inputs/golden (live in the data header, no mem chip).
+    sym_A = {j: BingoMemSymbol(f"A_k{j}") for j in range(k_chunks)}
+    sym_B = {(c, j): BingoMemSymbol(f"B_c{c}_k{j}")
+             for c in range(num_clusters) for j in range(k_chunks)}
+    sym_golden = {c: BingoMemSymbol(f"golden_D_c{c}") for c in range(num_clusters)}
+
+    # Per-cluster working buffers. DOUBLE-BUFFERED: a SEPARATE A/B buffer per
+    # (cluster, K-chunk) so the DMA core can prefetch chunk j+1 while the GEMM
+    # core still computes chunk j -- this removes the bubble the single reused
+    # buffer caused (no WAR stall waiting to reload). One D tile buffer per
+    # cluster (accumPrevC accumulates in place across chunks), plus an L3 landing
+    # buffer for the store. The per-chunk buffers are tiny (64 B each here), so
+    # the extra L1 footprint is negligible.
+    l1_A = {(c, j): BingoMemAlloc(f"l1_A_c{c}_k{j}", size=A_chunk_bytes, mem_level="L1", chip_id=0, cluster_id=c)
+            for c in range(num_clusters) for j in range(k_chunks)}
+    l1_B = {(c, j): BingoMemAlloc(f"l1_B_c{c}_k{j}", size=B_chunk_bytes, mem_level="L1", chip_id=0, cluster_id=c)
+            for c in range(num_clusters) for j in range(k_chunks)}
+    l1_D = {c: BingoMemAlloc(f"l1_D_c{c}", size=D_bytes, mem_level="L1", chip_id=0, cluster_id=c)
+            for c in range(num_clusters)}
+    l3_D = {c: BingoMemAlloc(f"l3_D_c{c}", size=D_bytes, mem_level="L3", chip_id=0)
+            for c in range(num_clusters)}
+
+    for c in range(num_clusters):
+        prev_gemm = None
+        for j in range(k_chunks):
+            load_A = BingoNode(
+                assigned_chiplet_id=0, assigned_cluster_id=c, assigned_core_id=DMA_CORE,
+                node_name=f"Load_A_c{c}_k{j}",
+                kernel_name="__snax_bingo_kernel_idma_1d_copy",
+                kernel_args=SnaxBingoKernelIdma1dCopyArgs(
+                    src_addr=sym_A[j], dst_addr=l1_A[(c, j)], size=A_chunk_bytes,
+                ),
+            )
+            load_B = BingoNode(
+                assigned_chiplet_id=0, assigned_cluster_id=c, assigned_core_id=DMA_CORE,
+                node_name=f"Load_B_c{c}_k{j}",
+                kernel_name="__snax_bingo_kernel_idma_1d_copy",
+                kernel_args=SnaxBingoKernelIdma1dCopyArgs(
+                    src_addr=sym_B[(c, j)], dst_addr=l1_B[(c, j)], size=B_chunk_bytes,
+                ),
+            )
+            # Chunk 0 seeds the register (accumPrevC=0); chunks >=1 accumulate.
+            gemm = BingoNode(
+                assigned_chiplet_id=0, assigned_cluster_id=c, assigned_core_id=GEMM_CORE,
+                node_name=f"Gemm_c{c}_k{j}",
+                kernel_name="__snax_bingo_kernel_gemm_full",
+                kernel_args=SnaxBingoKernelGemmFullArgs(
+                    input_A_addr=l1_A[(c, j)], input_B_addr=l1_B[(c, j)],
+                    input_C_addr=0, output_D_addr=l1_D[c],
+                    M=M, K=K_per_chunk, N=N_per_cluster,
+                    array_shape_idx=array_shape,
+                    transpose_A=transpose_A, transpose_B=transpose_B,
+                    accumPrevC=(0 if j == 0 else 1),
+                ),
+            )
+            for n in (load_A, load_B, gemm):
+                dfg.bingo_add_node(n)
+            dfg.bingo_add_edge(load_A, gemm)
+            dfg.bingo_add_edge(load_B, gemm)
+            # Double-buffered: this chunk's loads write their OWN buffer, so there
+            # is NO WAR edge from the prior GEMM -- the DMA core prefetches chunk
+            # j+1 while the GEMM core runs chunk j (squeezes out the bubble). The
+            # only ordering kept is the accumPrevC chain itself: the on-chip
+            # register must survive from one GEMM call to the next.
+            if prev_gemm is not None:
+                dfg.bingo_add_edge(prev_gemm, gemm)
+            prev_gemm = gemm
+
+        store = BingoNode(
+            assigned_chiplet_id=0, assigned_cluster_id=c, assigned_core_id=DMA_CORE,
+            node_name=f"Store_D_c{c}",
+            kernel_name="__snax_bingo_kernel_idma_1d_copy",
+            kernel_args=SnaxBingoKernelIdma1dCopyArgs(
+                src_addr=l1_D[c], dst_addr=l3_D[c], size=D_bytes,
+            ),
+        )
+        check = BingoNode(
+            assigned_chiplet_id=0, assigned_cluster_id=0, assigned_core_id=HOST_CORE,
+            node_name=f"Check_D_c{c}",
+            kernel_name="__host_bingo_kernel_check_result",
+            kernel_args=HostBingoKernelCheckResultArgs(
+                golden_data_addr=sym_golden[c],
+                output_data_addr=l3_D[c],
+                data_size=D_bytes,
+                name=f"D_c{c}",
+            ),
+        )
+        dfg.bingo_add_node(store)
+        dfg.bingo_add_node(check)
+        dfg.bingo_add_edge(prev_gemm, store)
+        dfg.bingo_add_edge(store, check)
+
+    total_nodes = num_clusters * (k_chunks * 3 + 2)
+    print(f"Built DFG: {total_nodes} nodes "
+          f"({num_clusters} parallel clusters x ({k_chunks} K-chunks + store + check), no reduction)")
+    print(f"  M={M}, N_per_cluster={N_per_cluster}, k_chunks={k_chunks}, K_per_chunk={K_per_chunk}, "
+          f"mesh={meshRow}x{tileSize}x{meshCol}")
+
+    dfg.bingo_compile_dfg(
+        "gemm_nsplit_accumprevc_4cluster", output_dir, args.output_offload_file_name,
+        extra_include_header_list=[DATA_HEADER],
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_nsplit_accumprevc_4cluster/nsplit_accumprevc_gemm_datagen.py
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_nsplit_accumprevc_4cluster/nsplit_accumprevc_gemm_datagen.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+Golden data generator for gemm_nsplit_accumprevc_4cluster.
+
+Design C: the GEMM is parallelized along N across `num_clusters` clusters; each
+cluster owns one output tile (M=1, N_per_cluster=1) and reduces over K in
+`k_chunks` chunks ON-CHIP via accumPrevC -- no host reduction.
+
+Data is emitted as embedded C arrays (BingoMemSymbol-backed), NOT a mem-chip
+mempool.bin, because the default single-chip RTL config has no mem chip.
+
+Emitted symbols (all in the generated data header):
+  - A_k{j}        int8 : the j-th K-chunk of A (M=1). Shared/broadcast to every
+                         cluster (each cluster DMAs its own copy into L1).
+  - B_c{c}_k{j}   int8 : cluster c's B operand for K-chunk j (its N-tile, K-chunk j)
+  - golden_D_c{c} int32: cluster c's full-K output tile = sum over j of A_k{j}*B_c{c}_k{j}
+
+Byte-layout contract (must match the VersaCore streamer AND block_gemm_golden_model):
+  A is A-layout  flat (m, k, meshRow,  tileSize)   <- golden does a.reshape(m,k,row,size)
+  B is B-layout  flat (n, k, meshCol,  tileSize)   <- golden does b.reshape(n,k,col,size)
+  D is D-layout  flat (m, n, meshRow,  meshCol)
+So A_full is generated as (M, K, meshRow, tileSize) and B_full as
+(num_clusters, K, meshCol, tileSize); slicing those gives the exact bytes both the
+device and the golden model consume.
+"""
+
+import numpy as np
+import sys
+import os
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../../../../../../../util/sim/"))
+import _usg_paths  # noqa: F401,E402  (registers util/sim/{common,gemm,xdma,ara} on sys.path)
+from data_utils import format_scalar_definition, format_vector_definition  # noqa E402
+from sim_golden_models import block_gemm_golden_model  # noqa E402
+
+np.random.seed(42)
+
+
+def emit_header_file(**kwargs):
+    lines = ["#include <stdint.h>"]
+
+    array_shape = kwargs["array_shape"]
+    data_type = kwargs.get("data_type", 0)  # int8
+    num_clusters = kwargs["num_clusters"]
+    M = kwargs["M"]
+    N_per_cluster = kwargs["N_per_cluster"]
+    k_chunks = kwargs["k_chunks"]
+    K_per_chunk = kwargs["K_per_chunk"]
+
+    # accumPrevC tile constraint: the on-chip accumulator holds exactly one
+    # output tile, so every GEMM call must produce a single tile.
+    if M != 1 or N_per_cluster != 1:
+        raise ValueError(
+            f"accumPrevC needs M==1 and N_per_cluster==1, got M={M} N_per_cluster={N_per_cluster}"
+        )
+    if k_chunks < 1:
+        raise ValueError(f"k_chunks ({k_chunks}) must be >= 1")
+
+    snax_acc_cfg = kwargs["snax_versacore_core_template"]["snax_acc_cfg"][0]
+    meshRow, tileSize, meshCol = snax_acc_cfg["snax_versacore_spatial_unrolling"][data_type][array_shape]
+
+    K = k_chunks * K_per_chunk          # global K-tile count
+    N = num_clusters * N_per_cluster    # global N-tile count (one tile per cluster)
+    D_size = M * N_per_cluster * meshRow * meshCol  # int32 elems per cluster tile
+
+    lines.append(
+        f"// Design-C N-split GEMM: M={M} K={K} N={N} (num_clusters={num_clusters}, "
+        f"N_per_cluster={N_per_cluster}, k_chunks={k_chunks}, K_per_chunk={K_per_chunk})"
+    )
+    lines.append(f"// mesh={meshRow}x{tileSize}x{meshCol}  (one D-tile = {D_size} int32)")
+
+    A_MIN, A_MAX = -128, 127
+    B_MIN, B_MAX = -128, 127
+
+    # A-layout (m,k,row,size); B-layout (n,k,col,size). One N-tile per cluster.
+    A_full = np.random.randint(A_MIN, A_MAX, size=(M, K, meshRow, tileSize)).astype(np.int8)
+    B_full = np.random.randint(B_MIN, B_MAX, size=(num_clusters, K, meshCol, tileSize)).astype(np.int8)
+
+    C_zero = np.zeros(D_size, dtype=np.int32)
+
+    def kslice(j):
+        return slice(j * K_per_chunk, (j + 1) * K_per_chunk)
+
+    # --- A per K-chunk (broadcast to all clusters) ---
+    for j in range(k_chunks):
+        A_kj = A_full[:, kslice(j), :, :].reshape(-1).copy().astype(np.int8)
+        lines.append(format_vector_definition("int8_t", f"A_k{j}", A_kj))
+
+    # --- B per cluster per K-chunk + per-cluster golden output tile ---
+    for c in range(num_clusters):
+        for j in range(k_chunks):
+            B_cj = B_full[c, kslice(j), :, :].reshape(-1).copy().astype(np.int8)
+            lines.append(format_vector_definition("int8_t", f"B_c{c}_k{j}", B_cj))
+
+        # Full-K golden for cluster c's tile = sum_j A_k{j} * B_c{c}_k{j}.
+        golden_D = block_gemm_golden_model(
+            M, K, N_per_cluster, meshRow, tileSize, meshCol,
+            A_full.reshape(-1).copy(), B_full[c].reshape(-1).copy(), 0, 0, C_zero.copy(),
+        ).astype(np.int32)
+
+        # Sanity: the accumPrevC chain sums per-chunk partials. Confirm that
+        # equals the full-K golden (linearity of the block GEMM over K).
+        acc = np.zeros(D_size, dtype=np.int64)
+        for j in range(k_chunks):
+            partial = block_gemm_golden_model(
+                M, K_per_chunk, N_per_cluster, meshRow, tileSize, meshCol,
+                A_full[:, kslice(j), :, :].reshape(-1).copy(),
+                B_full[c, kslice(j), :, :].reshape(-1).copy(), 0, 0, C_zero.copy(),
+            ).astype(np.int64)
+            acc += partial
+        assert np.array_equal(acc.astype(np.int32), golden_D), (
+            f"chunk-sum != full golden for cluster {c}"
+        )
+
+        lines.append(format_vector_definition("int32_t", f"golden_D_c{c}", golden_D))
+
+    # Informative scalars (not required by the runtime; main_bingo recomputes sizes).
+    for name, val in [
+        ("nsplit_num_clusters", num_clusters),
+        ("nsplit_M", M),
+        ("nsplit_K", K),
+        ("nsplit_N", N),
+        ("nsplit_k_chunks", k_chunks),
+        ("nsplit_K_per_chunk", K_per_chunk),
+        ("nsplit_meshRow", meshRow),
+        ("nsplit_tileSize", tileSize),
+        ("nsplit_meshCol", meshCol),
+    ]:
+        lines.append(format_scalar_definition("uint32_t", name, val))
+
+    return "\n\n".join(lines) + "\n"

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_nsplit_accumprevc_4cluster/params.hjson
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_nsplit_accumprevc_4cluster/params.hjson
@@ -1,0 +1,23 @@
+{
+    num_clusters: 4
+    // Design C: GEMM parallelized along N across the 4 clusters, with the K
+    // reduction done ON-CHIP inside each cluster via the VersaCore accumPrevC
+    // feature -- so there is NO host-side reduction (unlike gemm_ksplit_4cluster).
+    //
+    // Each cluster owns exactly ONE output tile (M=1, N_per_cluster=1) -- the
+    // accumPrevC tile constraint -- and walks K in `k_chunks` chunks. Chunk 0 runs
+    // with accumPrevC=0 (seed); chunks >=1 run with accumPrevC=1 (accumulate onto
+    // the on-chip accumulator register left by the previous GEMM call).
+    //
+    // Global GEMM seen by the 4 clusters together:
+    //   M = 1 (one M-tile), N = num_clusters * N_per_cluster, K = k_chunks * K_per_chunk
+    // M/K/N here are VersaCore TILE counts (mesh = 32x2x32 for array_shape 0).
+    array_shape: 0
+    data_type: 0
+    M: 1
+    N_per_cluster: 1
+    k_chunks: 2
+    K_per_chunk: 1
+    transposed_A: 0
+    transposed_B: 0
+}

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i4i4_i32_1cluster/.gitignore
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i4i4_i32_1cluster/.gitignore
@@ -1,0 +1,5 @@
+*.png
+*.h
+*.csv
+*.json
+build

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i4i4_i32_1cluster/Makefile
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i4i4_i32_1cluster/Makefile
@@ -1,0 +1,54 @@
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fanchen Kong <fanchen.kong@kuleuven.be>
+#
+# Per-precision GEMM cycle-sweep workload (i4i4_i32). Runs every (M,K,N,shape) in
+# gemm_psweep_lib.CONFIGS via the gemm_i4i4_i32 wrapper kernel; cycles are read
+# from the BINGO_TRACE_GEMM_FULL_RUN_* markers by sweep/gemm/gather_gemm_luts.py.
+MK_DIR   := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+HOST_APP_TYPE = offload_bingo_hw
+CHIP_TYPE     = single_chip
+WORKLOAD      = gemm_psweep_i4i4_i32_1cluster
+DEV_APP       = snax-bingo-offload
+SRCS = ../../src/offload_bingo_hw.c
+BINGO_HOST ?= 1
+INCL_DEVICE_BINARY ?= 1
+
+L1_SIZE_KB ?= 500
+
+DATA_CFG ?= $(MK_DIR)/params.hjson
+DATA_H = $(MK_DIR)/gemm_data.h
+OFFLOAD_H = $(MK_DIR)/offload_bingo_hw.h
+CONFIGS_JSON = $(MK_DIR)/configs.json
+BENDER   = bender
+SNITCH_ROOT = $(shell $(BENDER) path snitch_cluster)
+PLATFORM_H = $(MK_DIR)/../../../../../../../../target/sw/shared/platform/generated/occamy.h
+
+$(DATA_H) $(OFFLOAD_H) $(CONFIGS_JSON): $(MK_DIR)/main_bingo.py $(DATA_CFG) $(MK_DIR)/../../../../../../../../util/sim/gemm/gemm_psweep_lib.py $(MK_DIR)/../../../../../../../../util/sim/gemm/gemm_sim_utils.py
+	python3 $(MK_DIR)/main_bingo.py \
+		--output_dir $(MK_DIR) \
+		--data_h $(DATA_H) \
+		-c $(DATA_CFG) \
+		--hwcfg $(SNITCH_ROOT)/target/snitch_cluster/cfg/snax_versacore_to_cluster.hjson \
+		--configs_out $(CONFIGS_JSON) \
+		--l1_size_kb $(L1_SIZE_KB) \
+		--platformcfg $(PLATFORM_H)
+
+INCDIRS += $(MK_DIR)
+PARTIAL_OUTPUTS += $(DATA_H)
+PARTIAL_OUTPUTS += $(OFFLOAD_H)
+
+.PHONY: clean-data clean-offload clean
+clean-data:
+	rm -f $(DATA_H) $(CONFIGS_JSON)
+clean-offload:
+	rm -rf $(OFFLOAD_H) *.png *.csv
+clean: clean-data clean-offload
+
+gen-data: $(DATA_H)
+gen-offload: $(OFFLOAD_H)
+gen-configs: $(CONFIGS_JSON)
+
+include ../../../../common.mk

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i4i4_i32_1cluster/main_bingo.py
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i4i4_i32_1cluster/main_bingo.py
@@ -1,0 +1,20 @@
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fanchen Kong <fanchen.kong@kuleuven.be>
+#
+# Per-precision GEMM cycle sweep: i4i4_i32. All logic is shared in
+# util/sim/gemm/gemm_psweep_lib.py; this just selects the precision. The size grid
+# lives in gemm_psweep_lib.CONFIGS (shared across precisions for comparable LUTs).
+import os
+import sys
+
+# repo root is 8 levels up from this workload dir; the shared lib is in util/sim.
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 8)))
+sys.path.insert(0, os.path.join(_ROOT, "util", "sim"))
+import _usg_paths  # noqa: F401,E402  (registers util/sim/{common,gemm,xdma,ara} on sys.path)
+from gemm_psweep_lib import run  # noqa: E402
+
+if __name__ == "__main__":
+    run("i4i4_i32")

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i4i4_i32_1cluster/params.hjson
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i4i4_i32_1cluster/params.hjson
@@ -1,0 +1,3 @@
+{
+    num_clusters: 1
+}

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i4_f16_1cluster/.gitignore
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i4_f16_1cluster/.gitignore
@@ -1,0 +1,5 @@
+*.png
+*.h
+*.csv
+*.json
+build

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i4_f16_1cluster/Makefile
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i4_f16_1cluster/Makefile
@@ -1,0 +1,54 @@
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fanchen Kong <fanchen.kong@kuleuven.be>
+#
+# Per-precision GEMM cycle-sweep workload (i8i4_f16). Runs every (M,K,N,shape) in
+# gemm_psweep_lib.CONFIGS via the gemm_i8i4_f16 wrapper kernel; cycles are read
+# from the BINGO_TRACE_GEMM_FULL_RUN_* markers by sweep/gemm/gather_gemm_luts.py.
+MK_DIR   := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+HOST_APP_TYPE = offload_bingo_hw
+CHIP_TYPE     = single_chip
+WORKLOAD      = gemm_psweep_i8i4_f16_1cluster
+DEV_APP       = snax-bingo-offload
+SRCS = ../../src/offload_bingo_hw.c
+BINGO_HOST ?= 1
+INCL_DEVICE_BINARY ?= 1
+
+L1_SIZE_KB ?= 500
+
+DATA_CFG ?= $(MK_DIR)/params.hjson
+DATA_H = $(MK_DIR)/gemm_data.h
+OFFLOAD_H = $(MK_DIR)/offload_bingo_hw.h
+CONFIGS_JSON = $(MK_DIR)/configs.json
+BENDER   = bender
+SNITCH_ROOT = $(shell $(BENDER) path snitch_cluster)
+PLATFORM_H = $(MK_DIR)/../../../../../../../../target/sw/shared/platform/generated/occamy.h
+
+$(DATA_H) $(OFFLOAD_H) $(CONFIGS_JSON): $(MK_DIR)/main_bingo.py $(DATA_CFG) $(MK_DIR)/../../../../../../../../util/sim/gemm/gemm_psweep_lib.py $(MK_DIR)/../../../../../../../../util/sim/gemm/gemm_sim_utils.py
+	python3 $(MK_DIR)/main_bingo.py \
+		--output_dir $(MK_DIR) \
+		--data_h $(DATA_H) \
+		-c $(DATA_CFG) \
+		--hwcfg $(SNITCH_ROOT)/target/snitch_cluster/cfg/snax_versacore_to_cluster.hjson \
+		--configs_out $(CONFIGS_JSON) \
+		--l1_size_kb $(L1_SIZE_KB) \
+		--platformcfg $(PLATFORM_H)
+
+INCDIRS += $(MK_DIR)
+PARTIAL_OUTPUTS += $(DATA_H)
+PARTIAL_OUTPUTS += $(OFFLOAD_H)
+
+.PHONY: clean-data clean-offload clean
+clean-data:
+	rm -f $(DATA_H) $(CONFIGS_JSON)
+clean-offload:
+	rm -rf $(OFFLOAD_H) *.png *.csv
+clean: clean-data clean-offload
+
+gen-data: $(DATA_H)
+gen-offload: $(OFFLOAD_H)
+gen-configs: $(CONFIGS_JSON)
+
+include ../../../../common.mk

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i4_f16_1cluster/main_bingo.py
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i4_f16_1cluster/main_bingo.py
@@ -1,0 +1,20 @@
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fanchen Kong <fanchen.kong@kuleuven.be>
+#
+# Per-precision GEMM cycle sweep: i8i4_f16. All logic is shared in
+# util/sim/gemm/gemm_psweep_lib.py; this just selects the precision. The size grid
+# lives in gemm_psweep_lib.CONFIGS (shared across precisions for comparable LUTs).
+import os
+import sys
+
+# repo root is 8 levels up from this workload dir; the shared lib is in util/sim.
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 8)))
+sys.path.insert(0, os.path.join(_ROOT, "util", "sim"))
+import _usg_paths  # noqa: F401,E402  (registers util/sim/{common,gemm,xdma,ara} on sys.path)
+from gemm_psweep_lib import run  # noqa: E402
+
+if __name__ == "__main__":
+    run("i8i4_f16")

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i4_f16_1cluster/params.hjson
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i4_f16_1cluster/params.hjson
@@ -1,0 +1,3 @@
+{
+    num_clusters: 1
+}

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i4_i32_1cluster/.gitignore
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i4_i32_1cluster/.gitignore
@@ -1,0 +1,5 @@
+*.png
+*.h
+*.csv
+*.json
+build

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i4_i32_1cluster/Makefile
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i4_i32_1cluster/Makefile
@@ -1,0 +1,54 @@
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fanchen Kong <fanchen.kong@kuleuven.be>
+#
+# Per-precision GEMM cycle-sweep workload (i8i4_i32). Runs every (M,K,N,shape) in
+# gemm_psweep_lib.CONFIGS via the gemm_i8i4_i32 wrapper kernel; cycles are read
+# from the BINGO_TRACE_GEMM_FULL_RUN_* markers by sweep/gemm/gather_gemm_luts.py.
+MK_DIR   := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+HOST_APP_TYPE = offload_bingo_hw
+CHIP_TYPE     = single_chip
+WORKLOAD      = gemm_psweep_i8i4_i32_1cluster
+DEV_APP       = snax-bingo-offload
+SRCS = ../../src/offload_bingo_hw.c
+BINGO_HOST ?= 1
+INCL_DEVICE_BINARY ?= 1
+
+L1_SIZE_KB ?= 500
+
+DATA_CFG ?= $(MK_DIR)/params.hjson
+DATA_H = $(MK_DIR)/gemm_data.h
+OFFLOAD_H = $(MK_DIR)/offload_bingo_hw.h
+CONFIGS_JSON = $(MK_DIR)/configs.json
+BENDER   = bender
+SNITCH_ROOT = $(shell $(BENDER) path snitch_cluster)
+PLATFORM_H = $(MK_DIR)/../../../../../../../../target/sw/shared/platform/generated/occamy.h
+
+$(DATA_H) $(OFFLOAD_H) $(CONFIGS_JSON): $(MK_DIR)/main_bingo.py $(DATA_CFG) $(MK_DIR)/../../../../../../../../util/sim/gemm/gemm_psweep_lib.py $(MK_DIR)/../../../../../../../../util/sim/gemm/gemm_sim_utils.py
+	python3 $(MK_DIR)/main_bingo.py \
+		--output_dir $(MK_DIR) \
+		--data_h $(DATA_H) \
+		-c $(DATA_CFG) \
+		--hwcfg $(SNITCH_ROOT)/target/snitch_cluster/cfg/snax_versacore_to_cluster.hjson \
+		--configs_out $(CONFIGS_JSON) \
+		--l1_size_kb $(L1_SIZE_KB) \
+		--platformcfg $(PLATFORM_H)
+
+INCDIRS += $(MK_DIR)
+PARTIAL_OUTPUTS += $(DATA_H)
+PARTIAL_OUTPUTS += $(OFFLOAD_H)
+
+.PHONY: clean-data clean-offload clean
+clean-data:
+	rm -f $(DATA_H) $(CONFIGS_JSON)
+clean-offload:
+	rm -rf $(OFFLOAD_H) *.png *.csv
+clean: clean-data clean-offload
+
+gen-data: $(DATA_H)
+gen-offload: $(OFFLOAD_H)
+gen-configs: $(CONFIGS_JSON)
+
+include ../../../../common.mk

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i4_i32_1cluster/main_bingo.py
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i4_i32_1cluster/main_bingo.py
@@ -1,0 +1,20 @@
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fanchen Kong <fanchen.kong@kuleuven.be>
+#
+# Per-precision GEMM cycle sweep: i8i4_i32. All logic is shared in
+# util/sim/gemm/gemm_psweep_lib.py; this just selects the precision. The size grid
+# lives in gemm_psweep_lib.CONFIGS (shared across precisions for comparable LUTs).
+import os
+import sys
+
+# repo root is 8 levels up from this workload dir; the shared lib is in util/sim.
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 8)))
+sys.path.insert(0, os.path.join(_ROOT, "util", "sim"))
+import _usg_paths  # noqa: F401,E402  (registers util/sim/{common,gemm,xdma,ara} on sys.path)
+from gemm_psweep_lib import run  # noqa: E402
+
+if __name__ == "__main__":
+    run("i8i4_i32")

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i4_i32_1cluster/params.hjson
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i4_i32_1cluster/params.hjson
@@ -1,0 +1,3 @@
+{
+    num_clusters: 1
+}

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_f16_1cluster/.gitignore
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_f16_1cluster/.gitignore
@@ -1,0 +1,5 @@
+*.png
+*.h
+*.csv
+*.json
+build

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_f16_1cluster/Makefile
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_f16_1cluster/Makefile
@@ -1,0 +1,54 @@
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fanchen Kong <fanchen.kong@kuleuven.be>
+#
+# Per-precision GEMM cycle-sweep workload (i8i8_f16). Runs every (M,K,N,shape) in
+# gemm_psweep_lib.CONFIGS via the gemm_i8i8_f16 wrapper kernel; cycles are read
+# from the BINGO_TRACE_GEMM_FULL_RUN_* markers by sweep/gemm/gather_gemm_luts.py.
+MK_DIR   := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+HOST_APP_TYPE = offload_bingo_hw
+CHIP_TYPE     = single_chip
+WORKLOAD      = gemm_psweep_i8i8_f16_1cluster
+DEV_APP       = snax-bingo-offload
+SRCS = ../../src/offload_bingo_hw.c
+BINGO_HOST ?= 1
+INCL_DEVICE_BINARY ?= 1
+
+L1_SIZE_KB ?= 500
+
+DATA_CFG ?= $(MK_DIR)/params.hjson
+DATA_H = $(MK_DIR)/gemm_data.h
+OFFLOAD_H = $(MK_DIR)/offload_bingo_hw.h
+CONFIGS_JSON = $(MK_DIR)/configs.json
+BENDER   = bender
+SNITCH_ROOT = $(shell $(BENDER) path snitch_cluster)
+PLATFORM_H = $(MK_DIR)/../../../../../../../../target/sw/shared/platform/generated/occamy.h
+
+$(DATA_H) $(OFFLOAD_H) $(CONFIGS_JSON): $(MK_DIR)/main_bingo.py $(DATA_CFG) $(MK_DIR)/../../../../../../../../util/sim/gemm/gemm_psweep_lib.py $(MK_DIR)/../../../../../../../../util/sim/gemm/gemm_sim_utils.py
+	python3 $(MK_DIR)/main_bingo.py \
+		--output_dir $(MK_DIR) \
+		--data_h $(DATA_H) \
+		-c $(DATA_CFG) \
+		--hwcfg $(SNITCH_ROOT)/target/snitch_cluster/cfg/snax_versacore_to_cluster.hjson \
+		--configs_out $(CONFIGS_JSON) \
+		--l1_size_kb $(L1_SIZE_KB) \
+		--platformcfg $(PLATFORM_H)
+
+INCDIRS += $(MK_DIR)
+PARTIAL_OUTPUTS += $(DATA_H)
+PARTIAL_OUTPUTS += $(OFFLOAD_H)
+
+.PHONY: clean-data clean-offload clean
+clean-data:
+	rm -f $(DATA_H) $(CONFIGS_JSON)
+clean-offload:
+	rm -rf $(OFFLOAD_H) *.png *.csv
+clean: clean-data clean-offload
+
+gen-data: $(DATA_H)
+gen-offload: $(OFFLOAD_H)
+gen-configs: $(CONFIGS_JSON)
+
+include ../../../../common.mk

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_f16_1cluster/main_bingo.py
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_f16_1cluster/main_bingo.py
@@ -1,0 +1,20 @@
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fanchen Kong <fanchen.kong@kuleuven.be>
+#
+# Per-precision GEMM cycle sweep: i8i8_f16. All logic is shared in
+# util/sim/gemm/gemm_psweep_lib.py; this just selects the precision. The size grid
+# lives in gemm_psweep_lib.CONFIGS (shared across precisions for comparable LUTs).
+import os
+import sys
+
+# repo root is 8 levels up from this workload dir; the shared lib is in util/sim.
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 8)))
+sys.path.insert(0, os.path.join(_ROOT, "util", "sim"))
+import _usg_paths  # noqa: F401,E402  (registers util/sim/{common,gemm,xdma,ara} on sys.path)
+from gemm_psweep_lib import run  # noqa: E402
+
+if __name__ == "__main__":
+    run("i8i8_f16")

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_f16_1cluster/params.hjson
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_f16_1cluster/params.hjson
@@ -1,0 +1,3 @@
+{
+    num_clusters: 1
+}

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_i32_1cluster/.gitignore
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_i32_1cluster/.gitignore
@@ -1,0 +1,5 @@
+*.png
+*.h
+*.csv
+*.json
+build

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_i32_1cluster/Makefile
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_i32_1cluster/Makefile
@@ -1,0 +1,54 @@
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fanchen Kong <fanchen.kong@kuleuven.be>
+#
+# Per-precision GEMM cycle-sweep workload (i8i8_i32). Runs every (M,K,N,shape) in
+# gemm_psweep_lib.CONFIGS via the gemm_i8i8_i32 wrapper kernel; cycles are read
+# from the BINGO_TRACE_GEMM_FULL_RUN_* markers by sweep/gemm/gather_gemm_luts.py.
+MK_DIR   := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+HOST_APP_TYPE = offload_bingo_hw
+CHIP_TYPE     = single_chip
+WORKLOAD      = gemm_psweep_i8i8_i32_1cluster
+DEV_APP       = snax-bingo-offload
+SRCS = ../../src/offload_bingo_hw.c
+BINGO_HOST ?= 1
+INCL_DEVICE_BINARY ?= 1
+
+L1_SIZE_KB ?= 500
+
+DATA_CFG ?= $(MK_DIR)/params.hjson
+DATA_H = $(MK_DIR)/gemm_data.h
+OFFLOAD_H = $(MK_DIR)/offload_bingo_hw.h
+CONFIGS_JSON = $(MK_DIR)/configs.json
+BENDER   = bender
+SNITCH_ROOT = $(shell $(BENDER) path snitch_cluster)
+PLATFORM_H = $(MK_DIR)/../../../../../../../../target/sw/shared/platform/generated/occamy.h
+
+$(DATA_H) $(OFFLOAD_H) $(CONFIGS_JSON): $(MK_DIR)/main_bingo.py $(DATA_CFG) $(MK_DIR)/../../../../../../../../util/sim/gemm/gemm_psweep_lib.py $(MK_DIR)/../../../../../../../../util/sim/gemm/gemm_sim_utils.py
+	python3 $(MK_DIR)/main_bingo.py \
+		--output_dir $(MK_DIR) \
+		--data_h $(DATA_H) \
+		-c $(DATA_CFG) \
+		--hwcfg $(SNITCH_ROOT)/target/snitch_cluster/cfg/snax_versacore_to_cluster.hjson \
+		--configs_out $(CONFIGS_JSON) \
+		--l1_size_kb $(L1_SIZE_KB) \
+		--platformcfg $(PLATFORM_H)
+
+INCDIRS += $(MK_DIR)
+PARTIAL_OUTPUTS += $(DATA_H)
+PARTIAL_OUTPUTS += $(OFFLOAD_H)
+
+.PHONY: clean-data clean-offload clean
+clean-data:
+	rm -f $(DATA_H) $(CONFIGS_JSON)
+clean-offload:
+	rm -rf $(OFFLOAD_H) *.png *.csv
+clean: clean-data clean-offload
+
+gen-data: $(DATA_H)
+gen-offload: $(OFFLOAD_H)
+gen-configs: $(CONFIGS_JSON)
+
+include ../../../../common.mk

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_i32_1cluster/main_bingo.py
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_i32_1cluster/main_bingo.py
@@ -1,0 +1,20 @@
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fanchen Kong <fanchen.kong@kuleuven.be>
+#
+# Per-precision GEMM cycle sweep: i8i8_i32. All logic is shared in
+# util/sim/gemm/gemm_psweep_lib.py; this just selects the precision. The size grid
+# lives in gemm_psweep_lib.CONFIGS (shared across precisions for comparable LUTs).
+import os
+import sys
+
+# repo root is 8 levels up from this workload dir; the shared lib is in util/sim.
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 8)))
+sys.path.insert(0, os.path.join(_ROOT, "util", "sim"))
+import _usg_paths  # noqa: F401,E402  (registers util/sim/{common,gemm,xdma,ara} on sys.path)
+from gemm_psweep_lib import run  # noqa: E402
+
+if __name__ == "__main__":
+    run("i8i8_i32")

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_i32_1cluster/params.hjson
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_i32_1cluster/params.hjson
@@ -1,0 +1,3 @@
+{
+    num_clusters: 1
+}

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_i8_1cluster/.gitignore
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_i8_1cluster/.gitignore
@@ -1,0 +1,5 @@
+*.png
+*.h
+*.csv
+*.json
+build

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_i8_1cluster/Makefile
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_i8_1cluster/Makefile
@@ -1,0 +1,54 @@
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fanchen Kong <fanchen.kong@kuleuven.be>
+#
+# Per-precision GEMM cycle-sweep workload (i8i8_i8). Runs every (M,K,N,shape) in
+# gemm_psweep_lib.CONFIGS via the gemm_i8i8_i8 wrapper kernel; cycles are read
+# from the BINGO_TRACE_GEMM_FULL_RUN_* markers by sweep/gemm/gather_gemm_luts.py.
+MK_DIR   := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+HOST_APP_TYPE = offload_bingo_hw
+CHIP_TYPE     = single_chip
+WORKLOAD      = gemm_psweep_i8i8_i8_1cluster
+DEV_APP       = snax-bingo-offload
+SRCS = ../../src/offload_bingo_hw.c
+BINGO_HOST ?= 1
+INCL_DEVICE_BINARY ?= 1
+
+L1_SIZE_KB ?= 500
+
+DATA_CFG ?= $(MK_DIR)/params.hjson
+DATA_H = $(MK_DIR)/gemm_data.h
+OFFLOAD_H = $(MK_DIR)/offload_bingo_hw.h
+CONFIGS_JSON = $(MK_DIR)/configs.json
+BENDER   = bender
+SNITCH_ROOT = $(shell $(BENDER) path snitch_cluster)
+PLATFORM_H = $(MK_DIR)/../../../../../../../../target/sw/shared/platform/generated/occamy.h
+
+$(DATA_H) $(OFFLOAD_H) $(CONFIGS_JSON): $(MK_DIR)/main_bingo.py $(DATA_CFG) $(MK_DIR)/../../../../../../../../util/sim/gemm/gemm_psweep_lib.py $(MK_DIR)/../../../../../../../../util/sim/gemm/gemm_sim_utils.py
+	python3 $(MK_DIR)/main_bingo.py \
+		--output_dir $(MK_DIR) \
+		--data_h $(DATA_H) \
+		-c $(DATA_CFG) \
+		--hwcfg $(SNITCH_ROOT)/target/snitch_cluster/cfg/snax_versacore_to_cluster.hjson \
+		--configs_out $(CONFIGS_JSON) \
+		--l1_size_kb $(L1_SIZE_KB) \
+		--platformcfg $(PLATFORM_H)
+
+INCDIRS += $(MK_DIR)
+PARTIAL_OUTPUTS += $(DATA_H)
+PARTIAL_OUTPUTS += $(OFFLOAD_H)
+
+.PHONY: clean-data clean-offload clean
+clean-data:
+	rm -f $(DATA_H) $(CONFIGS_JSON)
+clean-offload:
+	rm -rf $(OFFLOAD_H) *.png *.csv
+clean: clean-data clean-offload
+
+gen-data: $(DATA_H)
+gen-offload: $(OFFLOAD_H)
+gen-configs: $(CONFIGS_JSON)
+
+include ../../../../common.mk

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_i8_1cluster/main_bingo.py
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_i8_1cluster/main_bingo.py
@@ -1,0 +1,20 @@
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fanchen Kong <fanchen.kong@kuleuven.be>
+#
+# Per-precision GEMM cycle sweep: i8i8_i8. All logic is shared in
+# util/sim/gemm/gemm_psweep_lib.py; this just selects the precision. The size grid
+# lives in gemm_psweep_lib.CONFIGS (shared across precisions for comparable LUTs).
+import os
+import sys
+
+# repo root is 8 levels up from this workload dir; the shared lib is in util/sim.
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 8)))
+sys.path.insert(0, os.path.join(_ROOT, "util", "sim"))
+import _usg_paths  # noqa: F401,E402  (registers util/sim/{common,gemm,xdma,ara} on sys.path)
+from gemm_psweep_lib import run  # noqa: E402
+
+if __name__ == "__main__":
+    run("i8i8_i8")

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_i8_1cluster/params.hjson
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_psweep_i8i8_i8_1cluster/params.hjson
@@ -1,0 +1,3 @@
+{
+    num_clusters: 1
+}

--- a/target/sw/host/runtime/libbingo/include/libbingo/device_kernel_args.h
+++ b/target/sw/host/runtime/libbingo/include/libbingo/device_kernel_args.h
@@ -234,6 +234,52 @@ __SNAX_KERNEL_ARGS_DEFINE __snax_bingo_kernel_gemm_full_args {
   BINGO_KERNEL_ARGS_TRAILER;
 } __snax_bingo_kernel_gemm_full_args_t;
 
+// ---------------------------------------------------------
+// Clean per-precision GEMM wrappers (over __snax_bingo_kernel_gemm_full)
+// ---------------------------------------------------------
+// These two structs back the precision-named GEMM wrapper kernels in
+// offload_hw_kernels/gemm.h, which hide gemm_full's 8 precision/quant flags.
+// Each wrapper picks the precision; the user only fills the GEMM operands/shape.
+//   plain  -> __snax_bingo_kernel_gemm_i8i8_i32 / _i8i4_i32 / _i4i4_i32 / _i8i4_f16 / _i8i8_f16
+//   quant  -> __snax_bingo_kernel_gemm_i8i8_i8  (adds requantization params)
+// Compute: D = A*B + C. A/B/C/D are 32-bit cluster-local (L1) addresses.
+
+// Shared "plain" GEMM args (int32 / int4-packed / fp16 outputs — no requant).
+__SNAX_KERNEL_ARGS_DEFINE __snax_bingo_kernel_gemm_args {
+  uint32_t input_A_addr;
+  uint32_t input_B_addr;
+  uint32_t input_C_addr;
+  uint32_t output_D_addr;
+  uint32_t M;
+  uint32_t K;
+  uint32_t N;
+  uint32_t array_shape_idx;
+  uint32_t transpose_A;
+  uint32_t transpose_B;
+  uint32_t accumPrevC;
+  BINGO_KERNEL_ARGS_TRAILER;
+} __snax_bingo_kernel_gemm_args_t;
+
+// Quantized GEMM args (int8 output): plain fields + requantization params.
+__SNAX_KERNEL_ARGS_DEFINE __snax_bingo_kernel_gemm_quant_args {
+  uint32_t input_A_addr;
+  uint32_t input_B_addr;
+  uint32_t input_C_addr;
+  uint32_t output_D_addr;
+  uint32_t M;
+  uint32_t K;
+  uint32_t N;
+  uint32_t array_shape_idx;
+  uint32_t transpose_A;
+  uint32_t transpose_B;
+  uint32_t accumPrevC;
+  uint32_t shift_i;
+  uint32_t multiplier_i;
+  int32_t  input_zp_i;
+  int32_t  output_zp_i;
+  BINGO_KERNEL_ARGS_TRAILER;
+} __snax_bingo_kernel_gemm_quant_args_t;
+
 // BINGO XDMA 1D Copy kernel args (same layout as cluster-level)
 __SNAX_KERNEL_ARGS_DEFINE __snax_bingo_kernel_xdma_1d_copy_args {
   uint32_t src_addr_hi;

--- a/target/sw/host/runtime/libbingo/mini_compiler/bingo_kernel_args.py
+++ b/target/sw/host/runtime/libbingo/mini_compiler/bingo_kernel_args.py
@@ -287,6 +287,137 @@ class SnaxBingoKernelGemmMinimalArgs(BingoKernelArgs):
         self._process_addr(self.output_D_addr, "output_D_addr", assignments, handle_name_map, split_64bit=False)
         return assignments
 
+# -------------------------------------------------------------------------
+# Clean per-precision GEMM wrappers (1:1 with the precision-named kernels in
+# offload_hw_kernels/gemm.h). The four "plain" precisions share one C struct
+# (__snax_bingo_kernel_gemm_args_t); the quantized one adds requant params
+# (__snax_bingo_kernel_gemm_quant_args_t). Pair each class with its kernel_name,
+# e.g. kernel_name="__snax_bingo_kernel_gemm_i8i4_i32" + SnaxBingoKernelGemmI8I4I32Args.
+# -------------------------------------------------------------------------
+class _SnaxBingoKernelGemmPlainArgs(BingoKernelArgs):
+    """Shared base for the plain GEMM wrappers (int32 / int4-packed / fp16 out,
+    no requantization). Subclasses are named per precision for a clean 1:1
+    kernel<->args mapping and add no fields."""
+    def __init__(self,
+                 input_A_addr: Union[BingoMemAlloc, int],
+                 input_B_addr: Union[BingoMemAlloc, int],
+                 input_C_addr: Union[BingoMemAlloc, int],
+                 output_D_addr: Union[BingoMemAlloc, int],
+                 M: int, K: int, N: int,
+                 array_shape_idx: int,
+                 transpose_A: int = 0,
+                 transpose_B: int = 0,
+                 accumPrevC: int = 0):
+        self.input_A_addr = input_A_addr
+        self.input_B_addr = input_B_addr
+        self.input_C_addr = input_C_addr
+        self.output_D_addr = output_D_addr
+        self.M = M
+        self.K = K
+        self.N = N
+        self.array_shape_idx = array_shape_idx
+        self.transpose_A = transpose_A
+        self.transpose_B = transpose_B
+        self.accumPrevC = accumPrevC
+
+    def get_struct_name(self) -> str:
+        return "__snax_bingo_kernel_gemm_args_t"
+
+    def get_c_field_assignments(self, handle_name_map: Dict[BingoMemAlloc, str]) -> Dict[str, str]:
+        assignments = {}
+        self._process_addr(self.input_A_addr, "input_A_addr", assignments, handle_name_map, split_64bit=False)
+        self._process_addr(self.input_B_addr, "input_B_addr", assignments, handle_name_map, split_64bit=False)
+        self._process_addr(self.input_C_addr, "input_C_addr", assignments, handle_name_map, split_64bit=False)
+        self._process_addr(self.output_D_addr, "output_D_addr", assignments, handle_name_map, split_64bit=False)
+        assignments["M"] = str(self.M)
+        assignments["K"] = str(self.K)
+        assignments["N"] = str(self.N)
+        assignments["array_shape_idx"] = str(self.array_shape_idx)
+        assignments["transpose_A"] = str(self.transpose_A)
+        assignments["transpose_B"] = str(self.transpose_B)
+        assignments["accumPrevC"] = str(self.accumPrevC)
+        return assignments
+
+
+# int8 x int8 -> int32  : kernel_name="__snax_bingo_kernel_gemm_i8i8_i32"
+class SnaxBingoKernelGemmI8I8I32Args(_SnaxBingoKernelGemmPlainArgs):
+    pass
+
+
+# int8 x int4 -> int32  (weight B int4) : "__snax_bingo_kernel_gemm_i8i4_i32"
+class SnaxBingoKernelGemmI8I4I32Args(_SnaxBingoKernelGemmPlainArgs):
+    pass
+
+
+# int4 x int4 -> int32  : "__snax_bingo_kernel_gemm_i4i4_i32"
+class SnaxBingoKernelGemmI4I4I32Args(_SnaxBingoKernelGemmPlainArgs):
+    pass
+
+
+# int8 x int4 -> fp16   (weight B int4) : "__snax_bingo_kernel_gemm_i8i4_f16"
+class SnaxBingoKernelGemmI8I4F16Args(_SnaxBingoKernelGemmPlainArgs):
+    pass
+
+
+# int8 x int8 -> fp16   (no input packing) : "__snax_bingo_kernel_gemm_i8i8_f16"
+class SnaxBingoKernelGemmI8I8F16Args(_SnaxBingoKernelGemmPlainArgs):
+    pass
+
+
+# int8 x int8 -> int8   (requantized) : "__snax_bingo_kernel_gemm_i8i8_i8"
+class SnaxBingoKernelGemmI8I8I8Args(BingoKernelArgs):
+    def __init__(self,
+                 input_A_addr: Union[BingoMemAlloc, int],
+                 input_B_addr: Union[BingoMemAlloc, int],
+                 input_C_addr: Union[BingoMemAlloc, int],
+                 output_D_addr: Union[BingoMemAlloc, int],
+                 M: int, K: int, N: int,
+                 array_shape_idx: int,
+                 shift_i: int,
+                 multiplier_i: int,
+                 input_zp_i: int,
+                 output_zp_i: int,
+                 transpose_A: int = 0,
+                 transpose_B: int = 0,
+                 accumPrevC: int = 0):
+        self.input_A_addr = input_A_addr
+        self.input_B_addr = input_B_addr
+        self.input_C_addr = input_C_addr
+        self.output_D_addr = output_D_addr
+        self.M = M
+        self.K = K
+        self.N = N
+        self.array_shape_idx = array_shape_idx
+        self.shift_i = shift_i
+        self.multiplier_i = multiplier_i
+        self.input_zp_i = input_zp_i
+        self.output_zp_i = output_zp_i
+        self.transpose_A = transpose_A
+        self.transpose_B = transpose_B
+        self.accumPrevC = accumPrevC
+
+    def get_struct_name(self) -> str:
+        return "__snax_bingo_kernel_gemm_quant_args_t"
+
+    def get_c_field_assignments(self, handle_name_map: Dict[BingoMemAlloc, str]) -> Dict[str, str]:
+        assignments = {}
+        self._process_addr(self.input_A_addr, "input_A_addr", assignments, handle_name_map, split_64bit=False)
+        self._process_addr(self.input_B_addr, "input_B_addr", assignments, handle_name_map, split_64bit=False)
+        self._process_addr(self.input_C_addr, "input_C_addr", assignments, handle_name_map, split_64bit=False)
+        self._process_addr(self.output_D_addr, "output_D_addr", assignments, handle_name_map, split_64bit=False)
+        assignments["M"] = str(self.M)
+        assignments["K"] = str(self.K)
+        assignments["N"] = str(self.N)
+        assignments["array_shape_idx"] = str(self.array_shape_idx)
+        assignments["transpose_A"] = str(self.transpose_A)
+        assignments["transpose_B"] = str(self.transpose_B)
+        assignments["accumPrevC"] = str(self.accumPrevC)
+        assignments["shift_i"] = str(self.shift_i)
+        assignments["multiplier_i"] = str(self.multiplier_i)
+        assignments["input_zp_i"] = str(self.input_zp_i)
+        assignments["output_zp_i"] = str(self.output_zp_i)
+        return assignments
+
 # BINGO XDMA 1D Copy
 class SnaxBingoKernelXdma1dCopyArgs(BingoKernelArgs):
     def __init__(self, src_addr: Union[BingoMemAlloc, int], dst_addr: Union[BingoMemAlloc, int], size: int):

--- a/util/sim/gemm/gemm_psweep_lib.py
+++ b/util/sim/gemm/gemm_psweep_lib.py
@@ -1,0 +1,314 @@
+# Copyright 2025 KU Leuven.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fanchen Kong <fanchen.kong@kuleuven.be>
+#
+# Shared builder for the per-precision GEMM cycle-sweep workloads
+# (gemm_psweep_<prec>_1cluster). Lives in util/sim/ alongside gemm_sim_utils.py;
+# each workload's main_bingo.py adds util/sim to sys.path and calls run("<prec>").
+#
+# Each workload runs ONE precision over a grid of (M, K, N, array_shape) sizes in
+# a single DFG, using the clean precision-named wrapper kernels
+# (offload_hw_kernels/gemm.h). Per config the DFG emits:
+#     Load_A -> Load_B -> Gemm<prec> -> Check_D
+# and the device GEMM kernel brackets its compute with BINGO_TRACE_GEMM_FULL_RUN_*
+# markers, so target/sim/automation/sweep/gemm/gather_gemm_luts.py recovers one
+# cycle count per config (paired with configs.json) — no host mcycle bracketing.
+#
+# Precision is split across workloads (one per precision) because it changes the
+# generated data layout (int4 packing / quant int8 / fp16 output) and so cannot
+# be looped inside one binary. Running the 5 workloads as a task list gives the
+# parallel multi-precision sweep.
+#
+# Data + golden come from the validated gemm_sim_utils.generate_gemm_test_data
+# (handles int4 packing, int8 requantization, int32->fp16) so this stays DRY.
+
+import os
+import sys
+import json
+import random
+import argparse
+import pathlib
+
+import hjson
+
+_THIS = os.path.dirname(os.path.abspath(__file__))         # .../util/sim/gemm
+ROOT = os.path.normpath(os.path.join(_THIS, "../../.."))   # repo root
+sys.path.append(os.path.join(ROOT, "target/sw/host/runtime/libbingo/mini_compiler"))
+sys.path.append(os.path.join(ROOT, "util/sim/common"))     # data_utils
+sys.path.append(_THIS)  # util/sim/gemm — gemm_sim_utils (sibling)
+
+from bingo_dfg import BingoDFG                                       # noqa: E402
+from bingo_node import BingoNode                                     # noqa: E402
+from bingo_mem_handle import BingoMemAlloc, BingoMemSymbol           # noqa: E402
+from bingo_platform import guard_cluster_count, parse_platform_cfg   # noqa: E402
+from bingo_kernel_args import (                                      # noqa: E402
+    SnaxBingoKernelIdma1dCopyArgs,
+    HostBingoKernelCheckResultArgs,
+    SnaxBingoKernelGemmI8I8I32Args,
+    SnaxBingoKernelGemmI8I4I32Args,
+    SnaxBingoKernelGemmI4I4I32Args,
+    SnaxBingoKernelGemmI8I4F16Args,
+    SnaxBingoKernelGemmI8I8F16Args,
+    SnaxBingoKernelGemmI8I8I8Args,
+)
+from gemm_sim_utils import generate_gemm_test_data                   # noqa: E402
+from data_utils import format_vector_definition                     # noqa: E402
+
+# Size grid (M, K, N, array_shape) in mesh-tile units — shared by all precisions
+# so the cycle LUTs are directly comparable. Same grid as gemm_sweep_1cluster.
+CONFIGS = [
+    # shape 0 (meshRow=32, tileSize=2, meshCol=32)
+    (1, 1, 1, 0), (1, 2, 1, 0), (1, 4, 1, 0), (1, 8, 1, 0),
+    (2, 2, 2, 0), (2, 4, 2, 0), (4, 4, 4, 0),
+    # shape 1 (meshRow=1, tileSize=16, meshCol=32)
+    (1, 1, 1, 1), (1, 2, 1, 1), (1, 4, 1, 1), (1, 8, 1, 1),
+    (2, 2, 2, 1), (2, 4, 2, 1), (4, 4, 4, 1),
+    # shape 2 (meshRow=16, tileSize=8, meshCol=16)
+    (1, 1, 1, 2), (1, 2, 1, 2), (1, 4, 1, 2), (1, 8, 1, 2),
+    (2, 2, 2, 2), (2, 4, 2, 2), (4, 4, 4, 2),
+]
+
+_CTYPE_BYTES = {"int8_t": 1, "uint16_t": 2, "int32_t": 4}
+
+# BINGO_SERIAL_C_D_WIDTH from gemm_shapes.h — the VersaCore C/D serializer beat
+# width (bits). The D-extension (requant->int8 / int32->fp16) output stage has two
+# kernel paths (offload_hw_kernels/gemm.h): when one narrowed output tile spans
+# >= one beat (meshRow*meshCol*d_bits >= 1024 — array_shape 0 and 2 here) the
+# streamer splits it into whole beats and works; when one tile is SMALLER than a
+# beat (the narrow meshRow=1 array_shape 1) the "pack multiple tiles into one
+# beat" path stalls the accelerator (observed: shape-1 hangs even when M*N fills
+# whole beats, e.g. (2,2,2,1)). So a D-extension config is only emittable when one
+# output tile already fills >= one serializer beat.
+_SERIAL_C_D_WIDTH = 1024
+
+
+def _d_extension_emittable(spec, gd):
+    """Whether the D-extension output stage can emit this config without stalling.
+    int32-output precisions have no D extension -> always emittable. For the
+    requant-int8 / int32->fp16 precisions, only configs whose single narrowed
+    output tile fills >= one serializer beat work (the small-tile packing path
+    hangs); in this sweep that excludes every array_shape-1 config."""
+    flags = spec["flags"]
+    if not (flags.get("quantization_enable", 0) or flags.get("int32tofp16_enable", 0)):
+        return True
+    d_bits = _CTYPE_BYTES[spec["d_ctype"]] * 8
+    one_output_tile_bits = gd["meshRow"] * gd["meshCol"] * d_bits
+    return one_output_tile_bits >= _SERIAL_C_D_WIDTH
+
+
+def _plain_args(cls):
+    def make(A, B, C, D, M, K, N, shape, gd):
+        return cls(input_A_addr=A, input_B_addr=B, input_C_addr=C, output_D_addr=D,
+                   M=M, K=K, N=N, array_shape_idx=shape)
+    return make
+
+
+def _quant_args(A, B, C, D, M, K, N, shape, gd):
+    cfg = gd["config"]
+    return SnaxBingoKernelGemmI8I8I8Args(
+        input_A_addr=A, input_B_addr=B, input_C_addr=C, output_D_addr=D,
+        M=M, K=K, N=N, array_shape_idx=shape,
+        shift_i=cfg["shift_i"], multiplier_i=cfg["multiplier_i"],
+        input_zp_i=cfg["input_zp_i"], output_zp_i=cfg["output_zp_i"])
+
+
+# Precision registry: name -> kernel symbol, datagen flags, args factory, D ctype.
+# Names + flags mirror the GEMM_PRECISIONS test contract and the gemm.h wrappers.
+PRECISIONS = {
+    "i8i8_i32": dict(
+        kernel="__snax_bingo_kernel_gemm_i8i8_i32",
+        flags=dict(int4_a_enable=0, int4_b_enable=0, quantization_enable=0, int32tofp16_enable=0),
+        make_args=_plain_args(SnaxBingoKernelGemmI8I8I32Args), d_ctype="int32_t"),
+    "i8i4_i32": dict(
+        kernel="__snax_bingo_kernel_gemm_i8i4_i32",
+        flags=dict(int4_a_enable=0, int4_b_enable=1, quantization_enable=0, int32tofp16_enable=0),
+        make_args=_plain_args(SnaxBingoKernelGemmI8I4I32Args), d_ctype="int32_t"),
+    "i4i4_i32": dict(
+        kernel="__snax_bingo_kernel_gemm_i4i4_i32",
+        flags=dict(int4_a_enable=1, int4_b_enable=1, quantization_enable=0, int32tofp16_enable=0),
+        make_args=_plain_args(SnaxBingoKernelGemmI4I4I32Args), d_ctype="int32_t"),
+    "i8i8_i8": dict(
+        kernel="__snax_bingo_kernel_gemm_i8i8_i8",
+        flags=dict(int4_a_enable=0, int4_b_enable=0, quantization_enable=1, int32tofp16_enable=0),
+        make_args=_quant_args, d_ctype="int8_t"),
+    "i8i4_f16": dict(
+        kernel="__snax_bingo_kernel_gemm_i8i4_f16",
+        flags=dict(int4_a_enable=0, int4_b_enable=1, quantization_enable=0, int32tofp16_enable=1),
+        make_args=_plain_args(SnaxBingoKernelGemmI8I4F16Args), d_ctype="uint16_t"),
+    "i8i8_f16": dict(
+        kernel="__snax_bingo_kernel_gemm_i8i8_f16",
+        flags=dict(int4_a_enable=0, int4_b_enable=0, quantization_enable=0, int32tofp16_enable=1),
+        make_args=_plain_args(SnaxBingoKernelGemmI8I8F16Args), d_ctype="uint16_t"),
+}
+
+
+def _pad64(n):
+    return (n + 63) & ~63
+
+
+def _gen_configs(configs, hwcfg, flags):
+    """One generate_gemm_test_data() per config (deterministic). Returns the list
+    of gemm_data dicts (A/B/D arrays + the config incl. any quant params)."""
+    random.seed(320)  # make requant params reproducible across builds
+    out = []
+    for (M, K, N, shape) in configs:
+        kwargs = {
+            **hwcfg,
+            "M": M, "K": K, "N": N, "array_shape": shape, "data_type": 0,
+            "transposed_A": 0, "transposed_B": 0,
+            "addNonZeroC": 0, "addZeroC": 1, "accumPrevC": 0,
+            **flags,
+        }
+        out.append(generate_gemm_test_data(**kwargs))
+    return out
+
+
+def _emit_header(gen, d_ctype):
+    lines = ["#include <stdint.h>"]
+    for i, gd in enumerate(gen):
+        lines.append("")
+        lines.append(f"// cfg{i}: M={gd['M']} K={gd['K']} N={gd['N']} "
+                     f"mesh={gd['meshRow']}x{gd['tileSize']}x{gd['meshCol']}")
+        lines.append(format_vector_definition("int8_t", f"A_cfg{i}", gd["A"]))
+        lines.append(format_vector_definition("int8_t", f"B_cfg{i}", gd["B"]))
+        lines.append(format_vector_definition(d_ctype, f"D_cfg{i}", gd["D"]))
+    return "\n".join(lines) + "\n"
+
+
+def _create_dfg(configs, gen, spec, platform):
+    dbytes = _CTYPE_BYTES[spec["d_ctype"]]
+    a_sz = [_pad64(len(gd["A"])) for gd in gen]   # xDMA-aligned
+    b_sz = [len(gd["B"]) for gd in gen]
+    d_sz = [len(gd["D"]) * dbytes for gd in gen]
+    max_A, max_B, max_D = max(a_sz), max(b_sz), max(d_sz)
+
+    dfg = BingoDFG(
+        num_chiplets=platform["num_chiplets"],
+        num_clusters_per_chiplet=platform["num_clusters_per_chiplet"],
+        num_cores_per_cluster=platform["num_cores_per_cluster"],
+        is_host_as_acc=True,
+        chiplet_ids=platform["chiplet_ids"],
+    )
+    gemm_core, dma_core, host_core = 0, 1, 2
+    l1_A = BingoMemAlloc("l1_A", size=max_A, mem_level="L1", chip_id=0, cluster_id=0)
+    l1_B = BingoMemAlloc("l1_B", size=max_B, mem_level="L1", chip_id=0, cluster_id=0)
+    l1_D = BingoMemAlloc("l1_D", size=max_D, mem_level="L1", chip_id=0, cluster_id=0)
+
+    prev_check = None
+    for i, (M, K, N, shape) in enumerate(configs):
+        A_l3 = BingoMemSymbol(f"A_cfg{i}")
+        B_l3 = BingoMemSymbol(f"B_cfg{i}")
+        D_l3 = BingoMemSymbol(f"D_cfg{i}")
+        load_A = BingoNode(
+            assigned_chiplet_id=0, assigned_cluster_id=0, assigned_core_id=dma_core,
+            node_name=f"Load_A_cfg{i}", kernel_name="__snax_bingo_kernel_idma_1d_copy",
+            kernel_args=SnaxBingoKernelIdma1dCopyArgs(A_l3, l1_A, a_sz[i]))
+        load_B = BingoNode(
+            assigned_chiplet_id=0, assigned_cluster_id=0, assigned_core_id=dma_core,
+            node_name=f"Load_B_cfg{i}", kernel_name="__snax_bingo_kernel_idma_1d_copy",
+            kernel_args=SnaxBingoKernelIdma1dCopyArgs(B_l3, l1_B, b_sz[i]))
+        gemm = BingoNode(
+            assigned_chiplet_id=0, assigned_cluster_id=0, assigned_core_id=gemm_core,
+            node_name=f"Gemm_cfg{i}", kernel_name=spec["kernel"],
+            kernel_args=spec["make_args"](l1_A, l1_B, 0, l1_D, M, K, N, shape, gen[i]))
+        check = BingoNode(
+            assigned_chiplet_id=0, assigned_cluster_id=0, assigned_core_id=host_core,
+            node_name=f"Check_cfg{i}", kernel_name="__host_bingo_kernel_check_result",
+            kernel_args=HostBingoKernelCheckResultArgs(
+                name=f"D{i}", golden_data_addr=D_l3, output_data_addr=l1_D,
+                data_size=min(d_sz[i], 256)))
+        for n in (load_A, load_B, gemm, check):
+            dfg.bingo_add_node(n)
+        dfg.bingo_add_edge(load_A, load_B)
+        dfg.bingo_add_edge(load_B, gemm)
+        dfg.bingo_add_edge(gemm, check)
+        if prev_check is not None:
+            dfg.bingo_add_edge(prev_check, load_A)
+        prev_check = check
+    return dfg
+
+
+def _check_fits_in_l1(gen, spec, l1_size_kb):
+    dbytes = _CTYPE_BYTES[spec["d_ctype"]]
+    budget = l1_size_kb * 1024
+    frag = lambda x: (x + 128 + 255) & ~255
+    for i, gd in enumerate(gen):
+        total = frag(_pad64(len(gd["A"]))) + frag(len(gd["B"])) + frag(len(gd["D"]) * dbytes)
+        assert total <= budget, (
+            f"cfg{i} (M={gd['M']},K={gd['K']},N={gd['N']}) needs {total} B > L1 {budget}")
+
+
+def _get_args():
+    p = argparse.ArgumentParser(description="per-precision GEMM cycle sweep")
+    p.add_argument("--output_dir", type=str, default=".")
+    p.add_argument("--output_offload_file_name", type=str, default="offload_bingo_hw.h")
+    p.add_argument("-c", "--cfg", type=pathlib.Path, required=True)
+    p.add_argument("--hwcfg", type=pathlib.Path, required=True)
+    p.add_argument("--platformcfg", type=pathlib.Path, required=True)
+    p.add_argument("--data_h", type=pathlib.Path, default=None)
+    p.add_argument("--configs_out", type=pathlib.Path, default=None)
+    p.add_argument("--l1_size_kb", type=int, default=500)
+    return p.parse_args()
+
+
+def run(prec_name):
+    """Entry point used by each gemm_psweep_<prec>_1cluster/main_bingo.py."""
+    assert prec_name in PRECISIONS, f"unknown precision '{prec_name}'"
+    spec = PRECISIONS[prec_name]
+    args = _get_args()
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    with open(args.cfg) as f:
+        param = hjson.loads(f.read())
+    with open(args.hwcfg) as f:
+        hwcfg = hjson.loads(f.read())
+
+    # Drop configs whose array_shape isn't exposed by the active hwcfg.
+    num_shapes = len(
+        hwcfg["snax_versacore_core_template"]["snax_acc_cfg"][0]
+        ["snax_versacore_spatial_unrolling"][0])
+    configs = [c for c in CONFIGS if c[3] < num_shapes]
+    if len(configs) != len(CONFIGS):
+        print(f"[gemm_psweep:{prec_name}] hwcfg exposes {num_shapes} shapes; "
+              f"kept {len(configs)}/{len(CONFIGS)} configs")
+
+    gen = _gen_configs(configs, hwcfg, spec["flags"])
+
+    # Drop configs the D-extension output serializer can't emit (would hang the
+    # accelerator). Only affects the requant-int8 / int32->fp16 precisions at the
+    # shapes/sizes whose narrowed output doesn't fill whole serializer beats
+    # (here: shape 1 with M*N too small). Padding M/N to fill a beat would change
+    # the measured GEMM, so these points are simply absent from the cycle LUT;
+    # int32-output precisions keep every config. Filter configs+gen together so
+    # configs.json (used by gather_gemm_luts.py) stays aligned with the DFG.
+    keep = [_d_extension_emittable(spec, gd) for gd in gen]
+    if not all(keep):
+        dropped = [c for c, k in zip(configs, keep) if not k]
+        print(f"[gemm_psweep:{prec_name}] dropped {len(dropped)} D-extension config(s) "
+              f"whose narrowed output can't fill whole {_SERIAL_C_D_WIDTH}-bit serializer "
+              f"beats (would hang): {dropped}")
+        configs = [c for c, k in zip(configs, keep) if k]
+        gen = [gd for gd, k in zip(gen, keep) if k]
+
+    _check_fits_in_l1(gen, spec, args.l1_size_kb)
+
+    if args.data_h is not None:
+        with open(args.data_h, "w") as f:
+            f.write(_emit_header(gen, spec["d_ctype"]))
+        print(f"Written data header: {args.data_h}")
+    if args.configs_out is not None:
+        with open(args.configs_out, "w") as f:
+            json.dump({"precision": prec_name, "configs": configs}, f, indent=2)
+        print(f"Written configs list: {args.configs_out}")
+
+    platform = parse_platform_cfg(args.platformcfg)
+    if not guard_cluster_count(param, platform, args.output_dir, args.output_offload_file_name):
+        return
+    dfg = _create_dfg(configs, gen, spec, platform)
+    dfg.bingo_compile_dfg(
+        f"Single-Chip GEMM precision sweep ({prec_name})",
+        args.output_dir, args.output_offload_file_name,
+        extra_include_header_list=["gemm_data.h"])
+    print(f"Generated DFG: {prec_name} x {len(configs)} configs")

--- a/util/sim/gemm/gemm_sim_utils.py
+++ b/util/sim/gemm/gemm_sim_utils.py
@@ -8,8 +8,18 @@
 
 import os
 import random
+import sys
 
 import numpy as np
+
+# Grouped util/sim layout: this module lives in util/sim/gemm/; its (lazy)
+# `from data_utils import ...` / `from sim_golden_models import ...` need the
+# sibling common/ dir on sys.path. Add common/ + the other engine subdirs.
+_USIM = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))  # util/sim
+for _sub in ("common", "gemm", "xdma", "ara"):
+    _p = os.path.join(_USIM, _sub)
+    if _p not in sys.path:
+        sys.path.append(_p)
 
 
 def _get_acc_cfg(cfg):
@@ -338,12 +348,38 @@ def generate_gemm_test_data(**kwargs):
     C_MIN, C_MAX = -2147483648, 2147483647
 
     A = np.random.randint(A_MIN, A_MAX, size=(M, K, meshRow, tileSize)).reshape(-1)
-    A_padded = np.pad(A, (0, (-A.size) % 64), mode="constant", constant_values=0)
-    A_to_emit = (
-        _pack_signed_nbit(A_padded, bit_width=4, pack_per_byte=2)
-        if int4_a_enable
-        else A_padded
-    )
+    if int4_a_enable:
+        # The A reader's sparse interconnect wires read-port i only to banks of
+        # parity (i % granularity_a); the device kernel rounds each int4 A K-tile
+        # stride UP to granularity_a banks (offload_hw_kernels/gemm.h). Pad each
+        # (meshRow*tileSize) K-tile here to that same width so the emitted byte
+        # offsets match exactly what the streamer reads — the pad lands in the
+        # skipped bank and is never consumed as A data. (Shapes whose tile is
+        # already a granularity_a-bank multiple are byte-identical to before, so
+        # i8i4/i4i4 on shapes 0/2 are unchanged; only int4 A at shape 1 grows.)
+        GRANULARITY_A = 2            # banks; mirrors hwcfg granularity_a
+        BANK_BITS = 64
+        A_ELEM_BITS = 4
+        elems_per_bank = BANK_BITS // A_ELEM_BITS       # 16 int4 per 64-bit bank
+        tile_elems = meshRow * tileSize
+        tile_banks = (tile_elems * A_ELEM_BITS + BANK_BITS - 1) // BANK_BITS
+        tile_banks_aligned = (
+            (tile_banks + GRANULARITY_A - 1) // GRANULARITY_A * GRANULARITY_A
+        )
+        padded_tile_elems = tile_banks_aligned * elems_per_bank
+        A_tiles = A.reshape(M * K, tile_elems)
+        A_tiles = np.pad(
+            A_tiles, ((0, 0), (0, padded_tile_elems - tile_elems)),
+            mode="constant", constant_values=0,
+        )
+        A_padded = A_tiles.reshape(-1)
+        A_padded = np.pad(A_padded, (0, (-A_padded.size) % 64),
+                          mode="constant", constant_values=0)
+        A_to_emit = _pack_signed_nbit(A_padded, bit_width=4, pack_per_byte=2)
+    else:
+        A_padded = np.pad(A, (0, (-A.size) % 64), mode="constant",
+                          constant_values=0)
+        A_to_emit = A_padded
 
     B = np.random.randint(B_MIN, B_MAX, size=(K, N, tileSize, meshCol)).reshape(-1)
     B_to_emit = (


### PR DESCRIPTION
## What's in this PR

**There are no RTL changes in the PR.**

### Core-level GEMM kernels (`offload_hw_kernels/gemm.h`)
`__snax_bingo_kernel_gemm_full` is refactored into a shared `__bingo_gemm_run` core
plus thin **precision-named wrapper kernels**. The MAC array is the int8
`snax_versacore_to_cluster` build (INT8×INT8 → INT32); precision is selected per call
by combining input-packing and output-stage flags (no rebuild):

| Wrapper kernel | A × B → D | Flags |
|---|---|---|
| `gemm_i8i8_i32` | int8 × int8 → int32 | (baseline) |
| `gemm_i8i4_i32` | int8 × int4 → int32 | `int4_b` |
| `gemm_i4i4_i32` | int4 × int4 → int32 | `int4_a + int4_b` |
| `gemm_i8i8_i8`  | int8 × int8 → int8  | `quantization` (requantize) |
| `gemm_i8i4_f16` | int8 × int4 → fp16  | `int4_b + int32tofp16` |
| `gemm_i8i8_f16` | int8 × int8 → fp16  | `int32tofp16` |

Input packing (`int4_a`/`int4_b`, written to the A/B reader extensions) and the output
stage (`quantization`/`int32tofp16`, written to the D reader-writer extension) are
independent, so `i8i8_f16` reuses the existing int32→fp16 path with no input packing.

### accumPrevC — on-chip K-reduction (`D = A*B + C`)
`accumPrevC` selects where the `+C` addend comes from: a C operand in memory, zero, or
the VersaCore accumulator register left from the previous call. The last mode lets a
chain of single-tile GEMMs (`M=N=1`, same `D_addr`) accumulate
`D = A0*B0 + A1*B1 + …` entirely on-chip, with no partial-C load/store between passes.
`gemm.h` documents the host↔hardware contract and the constraint (`accumPrevC=1`
requires `M==N==1`).

### Kernel-arg descriptors + registration
- `device_kernel_args.h`: plain (`__snax_bingo_kernel_gemm_args_t`) and quantized
  (`__snax_bingo_kernel_gemm_quant_args_t`) arg structs backing the wrappers.
- `bingo_kernel_args.py`: matching host mini-compiler arg classes.
- `snax_kernel_lib.h`: exports the wrapper kernels in the device symbol table.
- `gemm_shapes.h`: adds `BINGO_GRANULARITY_A` (A-reader sparse-interconnect access
  granularity), used for the granularity-aligned A K-tile stride.

### GEMM precision sweep + workloads
- `util/sim/gemm/gemm_psweep_lib.py`: the per-precision sweep driver (shared size
  grid, datagen, golden checks) and the precision registry.
- New workloads: `gemm_psweep_{i8i8_i32,i8i4_i32,i4i4_i32,i8i8_i8,i8i4_f16,i8i8_f16}_1cluster`
  and `gemm_nsplit_accumprevc_4cluster`.
- `sweep/gemm/{run_gemm_sweep.py, gather_gemm_luts.py, task_gemm.yaml}`: runs every
  precision over the shared `(M,K,N,array_shape)` grid and folds the
  `BINGO_TRACE_GEMM_FULL_RUN` cycle counts into a per-`(precision, shape)` LUT.
- `testing_workload_gen.py` / `versacore_params.py`: the versacore precision test
  suites (`GEMM_PRECISIONS`).
- `gemm_sim_utils.py`: GEMM golden model + datagen (int4 packing, int32→fp16/int8
  output references).

### `gemm_nsplit_accumprevc_4cluster` — on-chip K-reduction
A 4-cluster single-chip workload that exercises `accumPrevC` end to end. The GEMM is
parallelized **along N across the 4 clusters** (each cluster owns one disjoint output
tile) and the **K reduction is done on-chip** inside each cluster via `accumPrevC` — the
host never sums anything. Contrast `gemm_ksplit_4cluster`, which computes parallel
K-partials and then reduces them with a serial host `int32_add` chain.

- **On-chip K accumulation.** Each cluster walks K in `k_chunks` chunks on its private
  VersaCore accumulator register: chunk 0 runs `accumPrevC=0` (seed `reg = A0·B0`),
  chunks ≥1 run `accumPrevC=1` (`reg += Ak·Bk`), with `input_C_addr=0` throughout (the
  "+C" comes from the kept register). Back-to-back execution of the two GEMM calls on a
  cluster's GEMM core is guaranteed by bingo's per-`(chiplet,cluster,core)` sequencing,
  so the register survives between calls.
- **No reduction node.** `M=1, N_per_cluster=1` per call (the accumPrevC one-tile
  constraint) ⇒ `N_global = num_clusters`; the result is the four cluster tiles
  concatenated along N — there is no host reduction step.
- **Double-buffered.** A separate A/B buffer per K-chunk lets the DMA core prefetch
  chunk j+1 while the GEMM core runs chunk j, so the GEMM calls run back-to-back with no
  bubble; the only ordering edge kept is the `accumPrevC` chain itself.
- The workload header (`main_bingo.py`) documents a full numerical walkthrough and a
  per-cluster Gantt of the schedule. Config (`params.hjson`): `array_shape 0`
  (mesh 32×2×32), `M=1`, `N_per_cluster=1`, `k_chunks=2`, `K_per_chunk=1`.

> This is a 4-cluster **single-chip** workload, so it needs a 4-cluster single-chip sim
> config and is **not** exercised by the precision sweep below (which is 1-cluster) — it's
> the dedicated functional demonstrator for the `accumPrevC` chained-accumulation path.

## Validation

Ran the GEMM sweep on the single-chip config (VCS):

- **6/6 precision workloads PASS**, all host output checks (`Check [D*]: PASS`) green —
  no data mismatches.
- `gemm_cycles.csv` regenerated: **105 rows** across the 6 precisions.
- D-extension precisions (`*_i8`, `*_f16`) are measured on array-shapes 0 & 2; shape 1's
  narrowed output tile is smaller than one serializer beat (would stall), so those
  configs are dropped up front — consistent across `i8i8_i8` / `i8i4_f16` / `i8i8_f16`.

## Next Step
Now most of the GeMM kernel still use the SnaxBingoKernelGemmFullArgs, I will make a following branch to clean all those to make the precision explicit in calling the GeMM on the main_bingo.py. The SnaxBingoKernelGemmFullArgs will be backward compatable.