### PR TITLE
SW and RTL: New HW scheduler and the Minicompiler Feature

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -41,7 +41,7 @@ dependencies:
   hemaia_d2d_link:            { git:  https://github.com/KULeuven-MICAS/hemaia_d2d_link.git,            rev:     main    }
   hemaia_clk_rst_controller:  { git:  https://github.com/KULeuven-MICAS/hemaia_clk_rst_controller.git,  rev:     main    }
   floo_noc:                   { git:  https://github.com/KULeuven-MICAS/FlooNoC.git,                    rev:     main    }
-  bingo_hw_manager:           { git:  https://github.com/KULeuven-MICAS/bingo_hw_manager.git,           rev:     feature/identity-aware-dep-matrix    }
+  bingo_hw_manager:           { git:  https://github.com/KULeuven-MICAS/bingo_hw_manager.git,           rev:     main    }
 
 workspace:
   package_links:

--- a/Bender.yml
+++ b/Bender.yml
@@ -41,7 +41,7 @@ dependencies:
   hemaia_d2d_link:            { git:  https://github.com/KULeuven-MICAS/hemaia_d2d_link.git,            rev:     main    }
   hemaia_clk_rst_controller:  { git:  https://github.com/KULeuven-MICAS/hemaia_clk_rst_controller.git,  rev:     main    }
   floo_noc:                   { git:  https://github.com/KULeuven-MICAS/FlooNoC.git,                    rev:     main    }
-  bingo_hw_manager:           { git:  https://github.com/KULeuven-MICAS/bingo_hw_manager.git,           rev:     main    }
+  bingo_hw_manager:           { git:  https://github.com/KULeuven-MICAS/bingo_hw_manager.git,           rev:     feature/identity-aware-dep-matrix    }
 
 workspace:
   package_links:

--- a/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_parallel_dma_1cluster/params.hjson
+++ b/target/sw/host/apps/offload_bingo_hw/single_chip/workloads/gemm_parallel_dma_1cluster/params.hjson
@@ -9,7 +9,7 @@
     array_shape: 0
     transposed_A: 0
     transposed_B: 0
-    K: 32
+    K: 4
     N: 3
     M: 2
     // these two will config the addNewC = 1

--- a/target/sw/host/apps/offload_bingo_sw/single_chip/workloads/gemm_tiled_1cluster/tiled_gemm_workload_gen.py
+++ b/target/sw/host/apps/offload_bingo_sw/single_chip/workloads/gemm_tiled_1cluster/tiled_gemm_workload_gen.py
@@ -144,8 +144,8 @@ uint32_t __workload_gemm_tiled(bingo_task_t **task_list)
     check_kernel_tab_ready();
     printf_safe("Chip(%x, %x): [Host] Preparing GEMM Tiled Workload\\r\\n", get_current_chip_loc_x(), get_current_chip_loc_y());
 
-    uint32_t __snax_kernel_xdma_1d_copy_func_addr =
-        get_device_function("__snax_kernel_xdma_1d_copy");
+    uint32_t __snax_kernel_idma_1d_copy_func_addr =
+        get_device_function("__snax_kernel_idma_1d_copy");
     uint32_t __snax_kernel_versacore_load_compute_store_func_addr =
         get_device_function("__snax_kernel_versacore_load_compute_store");
     uint32_t __snax_kernel_start_gemm_and_wait_func_addr =
@@ -153,7 +153,7 @@ uint32_t __workload_gemm_tiled(bingo_task_t **task_list)
     uint32_t check_results_func_addr =
         get_device_function("__snax_kernel_check_results");
 
-    if (__snax_kernel_xdma_1d_copy_func_addr == SNAX_SYMTAB_END_FN_ADDR ||
+    if (__snax_kernel_idma_1d_copy_func_addr == SNAX_SYMTAB_END_FN_ADDR ||
         __snax_kernel_versacore_load_compute_store_func_addr == SNAX_SYMTAB_END_FN_ADDR || __snax_kernel_start_gemm_and_wait_func_addr == SNAX_SYMTAB_END_FN_ADDR ||
         check_results_func_addr == SNAX_SYMTAB_END_FN_ADDR)
     {
@@ -321,7 +321,7 @@ uint32_t __workload_gemm_tiled(bingo_task_t **task_list)
     
     data_str += ['''// Register task: load B matrix
                      bingo_task_t *task_xdma_l3_to_cluster_B =
-        bingo_task_create(__snax_kernel_xdma_1d_copy_func_addr,
+        bingo_task_create(__snax_kernel_idma_1d_copy_func_addr,
                           (uint32_t)(uintptr_t)(task_l3_to_cluster_args_B),
                           assigned_chip_id, assigned_cluster_id);
                           '''
@@ -331,7 +331,7 @@ uint32_t __workload_gemm_tiled(bingo_task_t **task_list)
         data_str += [
             f'''    // Register task: load A tile {tile_idx}
     bingo_task_t *task_xdma_l3_to_cluster_A{tile_idx} =
-        bingo_task_create(__snax_kernel_xdma_1d_copy_func_addr,
+        bingo_task_create(__snax_kernel_idma_1d_copy_func_addr,
                           (uint32_t)(uintptr_t)(task_l3_to_cluster_args_A{tile_idx}),
                           assigned_chip_id, assigned_cluster_id);
             '''
@@ -358,7 +358,7 @@ uint32_t __workload_gemm_tiled(bingo_task_t **task_list)
         data_str += [
             f'''    // Register task: store D tile {tile_idx}
     bingo_task_t *task_xdma_cluster_to_l3_D{tile_idx} =
-        bingo_task_create(__snax_kernel_xdma_1d_copy_func_addr,
+        bingo_task_create(__snax_kernel_idma_1d_copy_func_addr,
                           (uint32_t)(uintptr_t)(task_cluster_to_l3_args_D{tile_idx}),
                           assigned_chip_id, assigned_cluster_id);
             '''

--- a/target/sw/host/runtime/libbingo/include/libbingo/bingo_api.h
+++ b/target/sw/host/runtime/libbingo/include/libbingo/bingo_api.h
@@ -250,9 +250,11 @@ typedef struct hw_manager_task {
     uint8_t  assigned_core_id;     // Target core for execution
     bool     dep_check_enabled;    // Whether dependency checking is enabled
     uint8_t  dep_check_code;       // Dependency check code
+    uint8_t  dep_check_tag;        // Per-edge identity tag this check expects (EnableTaggedDeps)
     bool     dep_set_enabled;      // Whether dependency setting is enabled
     bool     dep_set_all_chiplet;  // Whether to set dependency on all chiplets
     uint8_t  dep_set_code;         // Dependency set code
+    uint8_t  dep_set_tag;          // Per-edge identity tag this set carries (EnableTaggedDeps)
     uint8_t  dep_set_chiplet_id;   // Chiplet ID to set dependency
     uint8_t  dep_set_cluster_id;   // Cluster ID to set dependency
     // DARTS Tier 1: Conditional Execution
@@ -290,20 +292,26 @@ static inline uint64_t encode_bingo_hw_manager_task_desc(bingo_hw_manager_task_d
     // Dep check code (N_CORES_PER_CLUSTER bits)
     encoded |= ENCODE_BITFIELD(desc.dep_check_code, DEP_CHECK_CODE_WIDTH, DEP_CHECK_CODE_SHIFT);
 
+    // Dep check tag (DEP_TAG_WIDTH bits) -- MSB of dep_check_info
+    encoded |= ENCODE_BITFIELD(desc.dep_check_tag, DEP_CHECK_TAG_WIDTH, DEP_CHECK_TAG_SHIFT);
+
     // Dep set enabled (1 bit)
     encoded |= ENCODE_BITFIELD(desc.dep_set_enabled, DEP_SET_ENABLED_WIDTH, DEP_SET_ENABLED_SHIFT);
 
     // Dep set all chiplet (1 bit)
     encoded |= ENCODE_BITFIELD(desc.dep_set_all_chiplet, DEP_SET_ALL_CHIPLET_WIDTH, DEP_SET_ALL_CHIPLET_SHIFT);
 
-    // Dep set code (N_CORES_PER_CLUSTER bits)
-    encoded |= ENCODE_BITFIELD(desc.dep_set_code, DEP_SET_CODE_WIDTH, DEP_SET_CODE_SHIFT);
-
     // Dep set chiplet ID (N_CHIPLETS_WIDTH bits)
     encoded |= ENCODE_BITFIELD(desc.dep_set_chiplet_id, DEP_SET_CHIPLET_ID_WIDTH, DEP_SET_CHIPLET_ID_SHIFT);
 
     // Dep set cluster ID (N_CLUSTERS_WIDTH bits)
     encoded |= ENCODE_BITFIELD(desc.dep_set_cluster_id, DEP_SET_CLUSTER_ID_WIDTH, DEP_SET_CLUSTER_ID_SHIFT);
+
+    // Dep set code (N_CORES_PER_CLUSTER bits)
+    encoded |= ENCODE_BITFIELD(desc.dep_set_code, DEP_SET_CODE_WIDTH, DEP_SET_CODE_SHIFT);
+
+    // Dep set tag (DEP_TAG_WIDTH bits) -- MSB of dep_set_info
+    encoded |= ENCODE_BITFIELD(desc.dep_set_tag, DEP_SET_TAG_WIDTH, DEP_SET_TAG_SHIFT);
 
     return encoded;
 }
@@ -321,11 +329,13 @@ static inline bingo_hw_manager_task_desc_t decode_bingo_hw_manager_task_desc(uin
     desc.assigned_core_id    = BINGO_EXTRACT_BITS(encoded, ASSIGNED_CORE_ID_SHIFT + ASSIGNED_CORE_ID_WIDTH - 1, ASSIGNED_CORE_ID_SHIFT);
     desc.dep_check_enabled   = BINGO_EXTRACT_BITS(encoded, DEP_CHECK_ENABLED_SHIFT + DEP_CHECK_ENABLED_WIDTH - 1, DEP_CHECK_ENABLED_SHIFT);
     desc.dep_check_code      = BINGO_EXTRACT_BITS(encoded, DEP_CHECK_CODE_SHIFT + DEP_CHECK_CODE_WIDTH - 1, DEP_CHECK_CODE_SHIFT);
+    desc.dep_check_tag       = BINGO_EXTRACT_BITS(encoded, DEP_CHECK_TAG_SHIFT + DEP_CHECK_TAG_WIDTH - 1, DEP_CHECK_TAG_SHIFT);
     desc.dep_set_enabled     = BINGO_EXTRACT_BITS(encoded, DEP_SET_ENABLED_SHIFT + DEP_SET_ENABLED_WIDTH - 1, DEP_SET_ENABLED_SHIFT);
     desc.dep_set_all_chiplet = BINGO_EXTRACT_BITS(encoded, DEP_SET_ALL_CHIPLET_SHIFT + DEP_SET_ALL_CHIPLET_WIDTH - 1, DEP_SET_ALL_CHIPLET_SHIFT);
-    desc.dep_set_code        = BINGO_EXTRACT_BITS(encoded, DEP_SET_CODE_SHIFT + DEP_SET_CODE_WIDTH - 1, DEP_SET_CODE_SHIFT);
     desc.dep_set_chiplet_id  = BINGO_EXTRACT_BITS(encoded, DEP_SET_CHIPLET_ID_SHIFT + DEP_SET_CHIPLET_ID_WIDTH - 1, DEP_SET_CHIPLET_ID_SHIFT);
     desc.dep_set_cluster_id  = BINGO_EXTRACT_BITS(encoded, DEP_SET_CLUSTER_ID_SHIFT + DEP_SET_CLUSTER_ID_WIDTH - 1, DEP_SET_CLUSTER_ID_SHIFT);
+    desc.dep_set_code        = BINGO_EXTRACT_BITS(encoded, DEP_SET_CODE_SHIFT + DEP_SET_CODE_WIDTH - 1, DEP_SET_CODE_SHIFT);
+    desc.dep_set_tag         = BINGO_EXTRACT_BITS(encoded, DEP_SET_TAG_SHIFT + DEP_SET_TAG_WIDTH - 1, DEP_SET_TAG_SHIFT);
     return desc;
 }
 

--- a/target/sw/host/runtime/libbingo/include/libbingo/bingo_utils.h
+++ b/target/sw/host/runtime/libbingo/include/libbingo/bingo_utils.h
@@ -44,12 +44,17 @@
 /// @param field_width   Width of the current field (if 0, defaults to 1)
 #define NEXT_SHIFT(current_shift, field_width) ((current_shift) + ((field_width) ? (field_width) : 1))
 
-// BINGO HW Task descriptor bit positions and widths
-// DARTS Tier 1: Conditional Execution fields (bits 0-5)
+// BINGO HW Task descriptor bit positions and widths.
+// MUST mirror the RTL packed struct bingo_hw_manager_task_desc_t (and the Python
+// bingo_pack_node) bit-for-bit: LSB->MSB the order is cond_exec_invert,
+// cond_exec_group_id, cond_exec_en, task_type, task_id, assigned_{chiplet,cluster,
+// core}_id, then dep_check_info {en, code, tag} and dep_set_info {en, all_chiplet,
+// chiplet_id, cluster_id, code, tag}.
+// DARTS Tier 1: Conditional Execution fields
 #define COND_EXEC_INVERT_WIDTH     1
 #define COND_EXEC_INVERT_SHIFT     0
 
-#define COND_EXEC_GROUP_ID_WIDTH   4
+#define COND_EXEC_GROUP_ID_WIDTH   5   // matches RTL cond_exec_group_id [4:0]
 #define COND_EXEC_GROUP_ID_SHIFT   NEXT_SHIFT(COND_EXEC_INVERT_SHIFT, COND_EXEC_INVERT_WIDTH)
 
 #define COND_EXEC_EN_WIDTH         1
@@ -76,20 +81,30 @@
 #define DEP_CHECK_CODE_WIDTH       N_CORES_PER_CLUSTER
 #define DEP_CHECK_CODE_SHIFT       NEXT_SHIFT(DEP_CHECK_ENABLED_SHIFT, DEP_CHECK_ENABLED_WIDTH)
 
+// Per-edge identity tag (EnableTaggedDeps). MUST match the hw_manager DepTagWidth.
+// One tag sits at the MSB of each dep_*_info struct (right after the dep code).
+#define DEP_TAG_WIDTH              4
+
+#define DEP_CHECK_TAG_WIDTH        DEP_TAG_WIDTH
+#define DEP_CHECK_TAG_SHIFT        NEXT_SHIFT(DEP_CHECK_CODE_SHIFT, DEP_CHECK_CODE_WIDTH)
+
 #define DEP_SET_ENABLED_WIDTH      1
-#define DEP_SET_ENABLED_SHIFT      NEXT_SHIFT(DEP_CHECK_CODE_SHIFT, DEP_CHECK_CODE_WIDTH)
+#define DEP_SET_ENABLED_SHIFT      NEXT_SHIFT(DEP_CHECK_TAG_SHIFT, DEP_CHECK_TAG_WIDTH)
 
 #define DEP_SET_ALL_CHIPLET_WIDTH  1
 #define DEP_SET_ALL_CHIPLET_SHIFT  NEXT_SHIFT(DEP_SET_ENABLED_SHIFT, DEP_SET_ENABLED_WIDTH)
 
-#define DEP_SET_CODE_WIDTH         N_CORES_PER_CLUSTER
-#define DEP_SET_CODE_SHIFT         NEXT_SHIFT(DEP_SET_ALL_CHIPLET_SHIFT, DEP_SET_ALL_CHIPLET_WIDTH)
-
 #define DEP_SET_CHIPLET_ID_WIDTH   N_CHIPLETS_WIDTH
-#define DEP_SET_CHIPLET_ID_SHIFT   NEXT_SHIFT(DEP_SET_CODE_SHIFT, DEP_SET_CODE_WIDTH)
+#define DEP_SET_CHIPLET_ID_SHIFT   NEXT_SHIFT(DEP_SET_ALL_CHIPLET_SHIFT, DEP_SET_ALL_CHIPLET_WIDTH)
 
 #define DEP_SET_CLUSTER_ID_WIDTH   N_CLUSTERS_PER_CHIPLET_WIDTH
 #define DEP_SET_CLUSTER_ID_SHIFT   NEXT_SHIFT(DEP_SET_CHIPLET_ID_SHIFT, DEP_SET_CHIPLET_ID_WIDTH)
+
+#define DEP_SET_CODE_WIDTH         N_CORES_PER_CLUSTER
+#define DEP_SET_CODE_SHIFT         NEXT_SHIFT(DEP_SET_CLUSTER_ID_SHIFT, DEP_SET_CLUSTER_ID_WIDTH)
+
+#define DEP_SET_TAG_WIDTH          DEP_TAG_WIDTH
+#define DEP_SET_TAG_SHIFT          NEXT_SHIFT(DEP_SET_CODE_SHIFT, DEP_SET_CODE_WIDTH)
 
 // Per-Kernel Scratchpad: defined in heterogeneous_runtime.h (shared between host/device)
 // bingo_kernel_scratchpad_t, BINGO_KERNEL_SCRATCHPAD_SIZE, BINGO_SP_PROFILE

--- a/target/sw/host/runtime/libbingo/mini_compiler/bingo_dfg.py
+++ b/target/sw/host/runtime/libbingo/mini_compiler/bingo_dfg.py
@@ -513,52 +513,6 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
     # ----------------------------------------------------------------
     # Identity-aware dependencies (EnableTaggedDeps): per-edge tags
     # ----------------------------------------------------------------
-    def bingo_transform_dfg_spill_for_tag_capacity(self, tag_width: int = 3) -> None:
-        """Auto-spill: bound every dep-matrix cell to <= 2**tag_width
-        concurrently-live edges so the later tag allocator fits a SMALL fixed HW
-        tag width (keeps the scoreboard tiny; the heavy lifting is here in SW).
-
-        Run BEFORE core sequencing / the dummy-set / dummy-check passes and the
-        dep-info assignment, so the ordering edges this inserts become REAL,
-        enforced dependencies.
-
-        Mechanism (a windowed throttle): group the original producer->consumer
-        edges by physical cell ``(consumer_chiplet, consumer_cluster, R, C)``; if a
-        cell has more than ``cap = 2**tag_width`` edges, add an ordering edge from
-        edge[i-cap]'s CONSUMER to edge[i]'s PRODUCER. Edge[i] then cannot set until
-        edge[i-cap] has drained, so at most ``cap`` of the cell's edges are ever
-        live at once. Only ADDS happens-before ordering, so it can never make
-        tagging unsafe (the allocator's per-cell coloring + 2**tag_width backstop
-        remain the correctness guard); cycle-creating throttles are skipped.
-        """
-        cap = 1 << tag_width
-        topo = list(nx.topological_sort(self))
-        pos = {n: i for i, n in enumerate(topo)}
-
-        cells: dict = {}                      # (chip, cl, R, C) -> [(producer, consumer), ...]
-        for u, v in self.edges():
-            if u.node_type == "dummy" or v.node_type == "dummy":
-                continue
-            cells.setdefault((v.assigned_chiplet_id, v.assigned_cluster_id,
-                              v.assigned_core_id, u.assigned_core_id), []).append((u, v))
-
-        for key, edges in cells.items():
-            if len(edges) <= cap:
-                continue                       # cell already within tag budget
-            edges.sort(key=lambda e: (pos[e[0]], pos[e[1]]))
-            for i in range(cap, len(edges)):
-                donor_consumer = edges[i - cap][1]   # whose drain frees a tag
-                recv_producer  = edges[i][0]         # who must wait for that tag
-                if donor_consumer is recv_producer:
-                    continue
-                if self.has_edge(donor_consumer, recv_producer):
-                    continue
-                if nx.has_path(self, recv_producer, donor_consumer):
-                    continue                   # would create a cycle -> skip (backstop covers it)
-                self.bingo_add_edge(donor_consumer, recv_producer)
-                print(f"Spill throttle cell c{key[0]}.{key[1]}[{key[2]}][{key[3]}]: "
-                      f"{donor_consumer.node_name} -> {recv_producer.node_name} (cap={cap})")
-
     def bingo_transform_dfg_allocate_dep_tags(self, tag_width: int = 3) -> None:
         """Assign per-edge identity tags so a consumer drains only ITS producer's
         increment, never a stray that happens to share the same dep-matrix cell.
@@ -577,8 +531,8 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
         (edge a may share b's tag iff a's consumer drains before b's producer
         sets): by Dilworth the minimum #chains == the largest antichain == the max
         number of simultaneously-live edges. Solved optimally via bipartite
-        matching. If a cell needs more than ``2**tag_width`` tags, raise -- run
-        bingo_transform_dfg_spill_for_tag_capacity first.
+        matching. If a cell needs more than ``2**tag_width`` tags, raise (reduce
+        the cell's concurrency in placement, or widen DepTagWidth).
         """
         max_tags = 1 << tag_width
         topo = list(nx.topological_sort(self))
@@ -668,8 +622,8 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
             if n_chains > max_tags:
                 raise ValueError(
                     f"dep-tag allocation: cell {key} needs {n_chains} > {max_tags} "
-                    f"concurrent tags (tag_width={tag_width}); run "
-                    f"bingo_transform_dfg_spill_for_tag_capacity or widen tag_width.")
+                    f"concurrent tags (tag_width={tag_width}); reduce this cell's "
+                    f"concurrency in placement or widen DepTagWidth.")
             for i, (su, cv) in enumerate(edges):
                 su.dep_set_tag = tag_of[i]
                 cv.dep_check_tag = tag_of[i]
@@ -2042,16 +1996,12 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
         # No-op for non-conditional DFGs (returns empty dict).
         self.bingo_compile_conditional_regions()
         self._validate_cerf_cross_group_edges()
-        # Serialize producers that share a (consumer_core, producer_core) counter cell
-        # across multiple consumers. MUST run before core sequencing so the producer
-        # ordering it adds is reflected in the topological sort used for sequencing.
-        # Identity-aware deps (default ON): bound each cell's concurrent edges to
-        # 2**DepTagWidth BEFORE the dummy/sequencing passes so the throttle edges
-        # become enforced dependencies. The legacy serialize_shared_counter_consumers
-        # mitigation has been removed -- per-edge tags supersede it. (Untagged mode
-        # has no counter-sharing mitigation.)
-        if self.enable_tagged_deps:
-            self.bingo_transform_dfg_spill_for_tag_capacity(tag_width=self.dep_tag_width)
+        # Identity-aware deps: per-edge tags are allocated LAST (after dep-info
+        # assignment). The allocator's min-chain-cover reuses a tag across edges
+        # that can never be live together (happens-before / same-core order), so
+        # no separate concurrency-bounding pass is needed. The legacy
+        # serialize_shared_counter_consumers mitigation was removed -- per-edge
+        # tags supersede it. (Untagged mode has no counter-sharing mitigation.)
         # Add Dummy Set/Check Nodes
         self.bingo_transform_add_core_sequencing_edges()
         self.bingo_transform_dfg_add_dummy_set_nodes()

--- a/target/sw/host/runtime/libbingo/mini_compiler/bingo_dfg.py
+++ b/target/sw/host/runtime/libbingo/mini_compiler/bingo_dfg.py
@@ -54,6 +54,12 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
         self.is_host_as_acc = is_host_as_acc
         assert num_chiplets == len(chiplet_ids) or chiplet_ids is None, "Length of chiplet_ids must match num_chiplets"
         self.chiplet_ids = chiplet_ids if chiplet_ids else list(range(num_chiplets))
+        # Identity-aware dependencies. Must match the hw_manager's EnableTaggedDeps
+        # / DepTagWidth parameters. When enabled, bingo_compile_dfg runs the spill +
+        # per-edge tag-allocation passes; the tag bits are always present in the
+        # packed descriptor (= 0 when disabled), matching the RTL struct layout.
+        self.enable_tagged_deps = True
+        self.dep_tag_width = 4
         # Node ID counter
         # Make sure the node id is starts from 0
         self.id = -1
@@ -403,97 +409,6 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
                     dummy_check_node.remote_dep_set_all = False
                     self.bingo_insert_node_between(pred, cur_node, dummy_check_node)
 
-    def bingo_transform_dfg_serialize_shared_counter_consumers(self) -> None:
-        """Serialize producers that feed a SHARED dependency-matrix counter cell.
-
-        Corner case
-        -----------
-        The dependency matrix holds one 8-bit *counter* per
-        ``(consumer_core, producer_core)`` pair, and a ``dep_check`` passes as
-        soon as ``counter[R][C] >= 1`` -- it knows the COUNT of pending signals
-        from core ``C``, not WHICH producer raised them. When two or more normal
-        consumers sit on the SAME core ``R`` and each waits (cross-core) on the
-        SAME producer core ``C``, they all check the SAME cell ``counter[R][C]``,
-        and every producer feeding any of them increments that one cell. A
-        consumer can then drain a *different* consumer's producer increment and
-        dispatch before its own input is actually ready.
-
-        Example: consumer A needs producers {a1 (early), a2 (late)} and consumer
-        B needs {b1 (early)}. All three increment ``counter[R][C]``; A's two
-        checks pass on the two EARLY increments (a1, b1) instead of (a1, a2), so
-        A dispatches before a2 has completed and reads stale data.
-
-        Fix
-        ---
-        Order the producers so each consumer's producers complete before the
-        next consumer's, matching the consumers' queue (topological) order.
-        Because the producers all live on the same core ``C``, this is a pure
-        queue-order / head-of-line serialization (same-core edges, no extra
-        cross-core counter traffic): add an edge from every earlier-consumer
-        producer to every later-consumer producer (skipping shared producers and
-        any edge that would create a cycle). The shared counter then accumulates
-        each consumer's increments contiguously and in order, so every consumer
-        drains exactly its own producers' signals.
-
-        MUST run BEFORE ``bingo_transform_add_core_sequencing_edges`` (and the
-        dummy_set / dummy_check passes): the per-core sequencing chains same-core
-        nodes in topological order, so the producer ordering added here is then
-        honored by the sequencing instead of conflicting with it.
-        """
-        topo = list(nx.topological_sort(self))
-        pos = {n: i for i, n in enumerate(topo)}
-        # (consumer_core R, producer_core C) -> [(consumer, [its producers on core C]), ...]
-        cells: dict = {}
-        for con in self.node_list:
-            if con.node_type != "normal":
-                continue
-            R = con.assigned_core_id
-            prods_by_core: dict = {}
-            for pred in self.predecessors(con):
-                if pred.assigned_core_id != R:                 # cross-core producer
-                    prods_by_core.setdefault(pred.assigned_core_id, []).append(pred)
-            for C, prods in prods_by_core.items():
-                # The dependency matrix is PER (chiplet, cluster): a consumer on
-                # cluster K checks that cluster's own counter[R][C], so only
-                # consumers on the SAME (chiplet, cluster) actually share a cell.
-                cells.setdefault((con.assigned_chiplet_id, con.assigned_cluster_id, R, C),
-                                 []).append((con, prods))
-
-        for (chip, cl, R, C), entries in cells.items():
-            if len(entries) < 2:                               # cell not shared -> nothing to do
-                continue
-            entries.sort(key=lambda e: pos[e[0]])              # consumers in queue (topo) order
-            for i in range(1, len(entries)):
-                prev_prods, cur_prods = entries[i - 1][1], entries[i][1]
-                for cp in cur_prods:
-                    for pp in prev_prods:
-                        if pp is cp or self.has_edge(pp, cp):
-                            continue
-                        if nx.has_path(self, cp, pp):
-                            # cp is already sequenced BEFORE pp on its core (a
-                            # pre-existing same-core chain orders cp ... pp). Adding
-                            # pp -> cp would cycle, so re-splice: cut cp's same-core
-                            # successor edge that leads to pp (pure sequencing -- cp's
-                            # data goes cross-core to its consumer), freeing cp; the
-                            # freed successor is re-sequenced by the later core
-                            # sequencing pass. Then order cp after pp below.
-                            succ = next((s for s in self.successors(cp)
-                                         if s.assigned_core_id == cp.assigned_core_id
-                                         and (s is pp or nx.has_path(self, s, pp))), None)
-                            if succ is None:
-                                continue                       # cannot safely reorder
-                            self.remove_edge(cp, succ)
-                            if nx.has_path(self, cp, pp):
-                                # another path still orders cp before pp: reordering
-                                # would cycle. Restore and leave this pair as-is.
-                                self.add_edge(cp, succ)
-                                continue
-                        self.add_edge(pp, cp)
-                        print(f"Serializing shared counter[c{chip}.{cl}][{R}][{C}]: "
-                              f"{pp.node_name} -> {cp.node_name} (producer of "
-                              f"'{entries[i-1][0].node_name}' before producer of "
-                              f"'{entries[i][0].node_name}')")
-
     def bingo_transform_add_core_sequencing_edges(self) -> int:
         """Add edges between consecutive tasks on the same core.
 
@@ -594,6 +509,171 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
                     cur_node.remote_dep_set_all = False
                     cur_node.dep_set_cluster_id = 0
                     cur_node.dep_set_chiplet_id = 0
+
+    # ----------------------------------------------------------------
+    # Identity-aware dependencies (EnableTaggedDeps): per-edge tags
+    # ----------------------------------------------------------------
+    def bingo_transform_dfg_spill_for_tag_capacity(self, tag_width: int = 3) -> None:
+        """Auto-spill: bound every dep-matrix cell to <= 2**tag_width
+        concurrently-live edges so the later tag allocator fits a SMALL fixed HW
+        tag width (keeps the scoreboard tiny; the heavy lifting is here in SW).
+
+        Run BEFORE core sequencing / the dummy-set / dummy-check passes and the
+        dep-info assignment, so the ordering edges this inserts become REAL,
+        enforced dependencies.
+
+        Mechanism (a windowed throttle): group the original producer->consumer
+        edges by physical cell ``(consumer_chiplet, consumer_cluster, R, C)``; if a
+        cell has more than ``cap = 2**tag_width`` edges, add an ordering edge from
+        edge[i-cap]'s CONSUMER to edge[i]'s PRODUCER. Edge[i] then cannot set until
+        edge[i-cap] has drained, so at most ``cap`` of the cell's edges are ever
+        live at once. Only ADDS happens-before ordering, so it can never make
+        tagging unsafe (the allocator's per-cell coloring + 2**tag_width backstop
+        remain the correctness guard); cycle-creating throttles are skipped.
+        """
+        cap = 1 << tag_width
+        topo = list(nx.topological_sort(self))
+        pos = {n: i for i, n in enumerate(topo)}
+
+        cells: dict = {}                      # (chip, cl, R, C) -> [(producer, consumer), ...]
+        for u, v in self.edges():
+            if u.node_type == "dummy" or v.node_type == "dummy":
+                continue
+            cells.setdefault((v.assigned_chiplet_id, v.assigned_cluster_id,
+                              v.assigned_core_id, u.assigned_core_id), []).append((u, v))
+
+        for key, edges in cells.items():
+            if len(edges) <= cap:
+                continue                       # cell already within tag budget
+            edges.sort(key=lambda e: (pos[e[0]], pos[e[1]]))
+            for i in range(cap, len(edges)):
+                donor_consumer = edges[i - cap][1]   # whose drain frees a tag
+                recv_producer  = edges[i][0]         # who must wait for that tag
+                if donor_consumer is recv_producer:
+                    continue
+                if self.has_edge(donor_consumer, recv_producer):
+                    continue
+                if nx.has_path(self, recv_producer, donor_consumer):
+                    continue                   # would create a cycle -> skip (backstop covers it)
+                self.bingo_add_edge(donor_consumer, recv_producer)
+                print(f"Spill throttle cell c{key[0]}.{key[1]}[{key[2]}][{key[3]}]: "
+                      f"{donor_consumer.node_name} -> {recv_producer.node_name} (cap={cap})")
+
+    def bingo_transform_dfg_allocate_dep_tags(self, tag_width: int = 3) -> None:
+        """Assign per-edge identity tags so a consumer drains only ITS producer's
+        increment, never a stray that happens to share the same dep-matrix cell.
+
+        Must run LAST -- after the dummy-set / dummy-check passes and the dep-info
+        assignment -- when every set/check operation is final. By then each
+        dependency is a single DIRECT edge ``set_node -> check_node`` (the dummy
+        passes split every fork / multi-producer into single-edge ops), so one
+        ``dep_set_tag`` and one ``dep_check_tag`` per node suffice.
+
+        Physical cell = ``(consumer_chiplet, consumer_cluster, R, C)`` with
+        ``R = consumer core`` and ``C = producer core`` (the bare-core column, so
+        cross-cluster / cross-chiplet producers fold onto the same cell -- the tag
+        is what keeps them apart). Per cell, the MINIMUM number of tags is a
+        minimum chain-cover of the edges under the happens-before partial order
+        (edge a may share b's tag iff a's consumer drains before b's producer
+        sets): by Dilworth the minimum #chains == the largest antichain == the max
+        number of simultaneously-live edges. Solved optimally via bipartite
+        matching. If a cell needs more than ``2**tag_width`` tags, raise -- run
+        bingo_transform_dfg_spill_for_tag_capacity first.
+        """
+        max_tags = 1 << tag_width
+        topo = list(nx.topological_sort(self))
+        pos = {n: i for i, n in enumerate(topo)}
+
+        cells: dict = {}                      # (chip, cl, R, C) -> [(set_node, check_node), ...]
+        set_edge_count: dict = {}
+        check_edge_count: dict = {}
+        for u, v in self.edges():
+            if not (u.dep_set_enable and v.dep_check_enable):
+                continue
+            C, R = u.assigned_core_id, v.assigned_core_id
+            if C not in v.dep_check_list or R not in u.dep_set_list:
+                continue                      # u sets / v checks, but not THIS pair
+            cells.setdefault((v.assigned_chiplet_id, v.assigned_cluster_id, R, C),
+                             []).append((u, v))
+            set_edge_count[u] = set_edge_count.get(u, 0) + 1
+            check_edge_count[v] = check_edge_count.get(v, 0) + 1
+
+        # A node driving/draining >1 edge would need >1 tag (only true broadcast
+        # dep-sets do this today). Tagging those needs a shared reserved tag per
+        # broadcast group -- not yet implemented; fail loudly instead of guessing.
+        multi = [n.node_id for n, c in set_edge_count.items() if c > 1] + \
+                [n.node_id for n, c in check_edge_count.items() if c > 1]
+        if multi:
+            raise NotImplementedError(
+                "dep-tag allocation: multi-target set/check ops (e.g. broadcast "
+                f"dep_set) need shared reserved tags; not yet supported: {multi}")
+
+        # Same-core HOL reachability: at runtime each core dispatches its tasks in
+        # topological (= push) order, so a same-core node that comes later is
+        # effectively reachable from an earlier one. Add those consecutive same-core
+        # edges to a SCRATCH graph used only for tag-reuse reachability (no real
+        # edges, dep info unchanged). This collapses same-core (diagonal R==C) cells
+        # -- which are serialized by the core queue -- to a chain, so they need few
+        # tags instead of one per edge.
+        hb = nx.DiGraph()
+        hb.add_nodes_from(self.nodes())
+        hb.add_edges_from(self.edges())
+        by_core_hb: dict = {}
+        for nd in topo:
+            by_core_hb.setdefault((nd.assigned_chiplet_id, nd.assigned_cluster_id,
+                                   nd.assigned_core_id), []).append(nd)
+        for seq in by_core_hb.values():
+            for i in range(len(seq) - 1):
+                hb.add_edge(seq[i], seq[i + 1])
+
+        for key, edges in cells.items():
+            edges.sort(key=lambda e: (pos[e[0]], pos[e[1]]))
+            n = len(edges)
+            # reach[a] = nodes reachable from edge a's consumer (its drain point)
+            reach = [nx.descendants(hb, cv) for (_su, cv) in edges]
+            B = nx.Graph()
+            for a in range(n):
+                B.add_node(("L", a)); B.add_node(("R", a))
+            for a in range(n):
+                for b in range(n):
+                    if a == b:
+                        continue
+                    # a precedes b (may share a tag) iff edge a's drain happens
+                    # before edge b's set: they meet at one node (a's consumer IS
+                    # b's producer), b's producer is reachable from a's consumer,
+                    # or a's consumer and b's producer are on the SAME core (run
+                    # serially in topological = push = HOL dispatch order, which
+                    # collapses same-core diagonal cells with no explicit path).
+                    if edges[b][0] is edges[a][1] or edges[b][0] in reach[a]:
+                        B.add_edge(("L", a), ("R", b))
+            match = (nx.algorithms.bipartite.hopcroft_karp_matching(
+                         B, top_nodes=[("L", a) for a in range(n)])
+                     if B.number_of_edges() else {})
+            succ, has_pred = {}, set()
+            for node, m in match.items():
+                if node[0] == "L":
+                    succ[node[1]] = m[1]; has_pred.add(m[1])
+            tag_of, n_chains = {}, 0
+            for a in range(n):
+                if a in has_pred:
+                    continue                   # not a chain head
+                cur = a
+                while True:
+                    tag_of[cur] = n_chains
+                    if cur in succ:
+                        cur = succ[cur]
+                    else:
+                        break
+                n_chains += 1
+            if n_chains > max_tags:
+                raise ValueError(
+                    f"dep-tag allocation: cell {key} needs {n_chains} > {max_tags} "
+                    f"concurrent tags (tag_width={tag_width}); run "
+                    f"bingo_transform_dfg_spill_for_tag_capacity or widen tag_width.")
+            for i, (su, cv) in enumerate(edges):
+                su.dep_set_tag = tag_of[i]
+                cv.dep_check_tag = tag_of[i]
+
     # ----------------------------------------------------------------
     # DARTS Tier 1: Conditional Execution Compilation
     # ----------------------------------------------------------------
@@ -1028,7 +1108,12 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
             dep_check_code_val |= (1 << core_id)
         packed_val |= (dep_check_code_val << current_shift)
         current_shift += num_cores
-        
+
+        # dep_check_tag (dep_tag_width bits) — MSB of dep_check_info; always present
+        # to match the RTL struct (0 when identity-aware deps are disabled).
+        packed_val |= ((node.dep_check_tag or 0) << current_shift)
+        current_shift += self.dep_tag_width
+
         # 7. dep_set_info
         
         # dep_set_en (1 bit)
@@ -1055,7 +1140,11 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
             dep_set_code_val |= (1 << core_id)
         packed_val |= (dep_set_code_val << current_shift)
         current_shift += num_cores
-        
+
+        # dep_set_tag (dep_tag_width bits) — MSB of dep_set_info; always present.
+        packed_val |= ((node.dep_set_tag or 0) << current_shift)
+        current_shift += self.dep_tag_width
+
         # Check if we exceeded 64 bits
         if current_shift > 64:
             raise ValueError(f"Packed task descriptor exceeds 64 bits: {current_shift} bits used.")
@@ -1118,7 +1207,10 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
         
         fields['dep_check_code'] = (packed_val >> current_shift) & ((1 << num_cores) - 1)
         current_shift += num_cores
-        
+
+        fields['dep_check_tag'] = (packed_val >> current_shift) & ((1 << self.dep_tag_width) - 1)
+        current_shift += self.dep_tag_width
+
         # 7. dep_set_info
         fields['dep_set_en'] = (packed_val >> current_shift) & 0x1
         current_shift += 1
@@ -1134,7 +1226,10 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
         
         fields['dep_set_code'] = (packed_val >> current_shift) & ((1 << num_cores) - 1)
         current_shift += num_cores
-        
+
+        fields['dep_set_tag'] = (packed_val >> current_shift) & ((1 << self.dep_tag_width) - 1)
+        current_shift += self.dep_tag_width
+
         return fields
     def bingo_visualize_dfg(self, filename: str = "dfg_visualization", figsize: tuple = (20, 16)) -> None:
         """Visualize the DFG with different shapes for task types and colors for chiplets."""
@@ -1950,7 +2045,13 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
         # Serialize producers that share a (consumer_core, producer_core) counter cell
         # across multiple consumers. MUST run before core sequencing so the producer
         # ordering it adds is reflected in the topological sort used for sequencing.
-        self.bingo_transform_dfg_serialize_shared_counter_consumers()
+        # Identity-aware deps (default ON): bound each cell's concurrent edges to
+        # 2**DepTagWidth BEFORE the dummy/sequencing passes so the throttle edges
+        # become enforced dependencies. The legacy serialize_shared_counter_consumers
+        # mitigation has been removed -- per-edge tags supersede it. (Untagged mode
+        # has no counter-sharing mitigation.)
+        if self.enable_tagged_deps:
+            self.bingo_transform_dfg_spill_for_tag_capacity(tag_width=self.dep_tag_width)
         # Add Dummy Set/Check Nodes
         self.bingo_transform_add_core_sequencing_edges()
         self.bingo_transform_dfg_add_dummy_set_nodes()
@@ -1964,7 +2065,11 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
         # Assign Dep Info
         self.bingo_assign_normal_node_dep_set_info()
         self.bingo_assign_normal_node_dep_check_info()
-        
+        # Identity-aware deps: allocate per-edge tags LAST, once every set/check
+        # op (incl. dummies) is final. Packed into the descriptor by bingo_pack_node.
+        if self.enable_tagged_deps:
+            self.bingo_transform_dfg_allocate_dep_tags(tag_width=self.dep_tag_width)
+
         # 2. Emit C Code
         self.bingo_emit_offload_c_code(
             app_name=app_name,

--- a/target/sw/host/runtime/libbingo/mini_compiler/bingo_dfg.py
+++ b/target/sw/host/runtime/libbingo/mini_compiler/bingo_dfg.py
@@ -251,7 +251,15 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
 
                 for core_id, group in remote_succs_by_core.items():
                     chiplets_in_group = set(s.assigned_chiplet_id for s in group)
-                    if len(chiplets_in_group) == (self.num_chiplets - 1):
+                    # A genuine broadcast covers ALL other chiplets AND there are at
+                    # least two of them. The `num_chiplets > 2` guard is essential:
+                    # at num_chiplets==2 a single point-to-point remote edge trivially
+                    # "covers all (one) other chiplets" and would be mis-flagged as a
+                    # broadcast -> the RTL multicasts (AW=0xFF) to EVERY chiplet,
+                    # including the producer's own, leaving a stray (tagged) set with
+                    # no consumer to drain it. Such a single edge must use a targeted
+                    # dummy_set instead.
+                    if self.num_chiplets > 2 and len(chiplets_in_group) == (self.num_chiplets - 1):
                         # Broadcast: one dummy_set blocks cur_node's core and sets the bit on all chiplets
                         print(f"Node {cur_node.node_name} is a broadcast node to set all chiplets for core {core_id}.")
                         dummy_set_node = BingoNode(
@@ -518,28 +526,43 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
         increment, never a stray that happens to share the same dep-matrix cell.
 
         Must run LAST -- after the dummy-set / dummy-check passes and the dep-info
-        assignment -- when every set/check operation is final. By then each
-        dependency is a single DIRECT edge ``set_node -> check_node`` (the dummy
-        passes split every fork / multi-producer into single-edge ops), so one
-        ``dep_set_tag`` and one ``dep_check_tag`` per node suffice.
+        assignment -- when every set/check operation is final.
 
         Physical cell = ``(consumer_chiplet, consumer_cluster, R, C)`` with
         ``R = consumer core`` and ``C = producer core`` (the bare-core column, so
         cross-cluster / cross-chiplet producers fold onto the same cell -- the tag
-        is what keeps them apart). Per cell, the MINIMUM number of tags is a
-        minimum chain-cover of the edges under the happens-before partial order
-        (edge a may share b's tag iff a's consumer drains before b's producer
-        sets): by Dilworth the minimum #chains == the largest antichain == the max
-        number of simultaneously-live edges. Solved optimally via bipartite
-        matching. If a cell needs more than ``2**tag_width`` tags, raise (reduce
-        the cell's concurrency in placement, or widen DepTagWidth).
+        is what keeps them apart). A task descriptor carries exactly ONE
+        ``dep_set_tag`` and ONE ``dep_check_tag``, so the tag is a property of the
+        NODE, not of the edge: every set->check edge ``(u, v)`` requires
+        ``u.dep_set_tag == v.dep_check_tag``.
+
+        Two kinds of set op exist after the dummy passes:
+
+        * **Single-edge** ``set -> check``. The common case (the dummy passes split
+          local forks / multi-core consumers into single-edge ops). Per cell, the
+          MINIMUM number of tags is a minimum chain-cover of these edges under the
+          happens-before partial order (edge a may share b's tag iff a's consumer
+          drains before b's producer sets): by Dilworth the minimum #chains == the
+          largest antichain == the max number of simultaneously-live edges. Solved
+          optimally via bipartite matching.
+
+        * **Broadcast** ``set -> {check_chip_i}`` (``remote_dep_set_all``). One set
+          op writes a single tag to one ``(cluster, R, C)`` position replicated on
+          every target chiplet, so ALL of its edges -- which land in one cell per
+          chiplet -- and all of their consumer checks MUST share ONE reserved tag.
+          That tag is reserved (excluded from the local chain-cover) in every cell
+          the broadcast touches. Broadcast groups that land in a common cell get
+          distinct tags (greedy graph-colouring on the share-a-cell conflict).
+
+        If a cell needs more than ``2**tag_width`` tags, raise (reduce the cell's
+        concurrency in placement, or widen DepTagWidth).
         """
         max_tags = 1 << tag_width
         topo = list(nx.topological_sort(self))
         pos = {n: i for i, n in enumerate(topo)}
 
         cells: dict = {}                      # (chip, cl, R, C) -> [(set_node, check_node), ...]
-        set_edge_count: dict = {}
+        set_edges: dict = {}                  # set_node -> [(set_node, check_node), ...]
         check_edge_count: dict = {}
         for u, v in self.edges():
             if not (u.dep_set_enable and v.dep_check_enable):
@@ -549,18 +572,52 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
                 continue                      # u sets / v checks, but not THIS pair
             cells.setdefault((v.assigned_chiplet_id, v.assigned_cluster_id, R, C),
                              []).append((u, v))
-            set_edge_count[u] = set_edge_count.get(u, 0) + 1
+            set_edges.setdefault(u, []).append((u, v))
             check_edge_count[v] = check_edge_count.get(v, 0) + 1
 
-        # A node driving/draining >1 edge would need >1 tag (only true broadcast
-        # dep-sets do this today). Tagging those needs a shared reserved tag per
-        # broadcast group -- not yet implemented; fail loudly instead of guessing.
-        multi = [n.node_id for n, c in set_edge_count.items() if c > 1] + \
-                [n.node_id for n, c in check_edge_count.items() if c > 1]
-        if multi:
+        # A dep_check op draining >1 producer edge has no HW representation: it owns
+        # one dep_check_tag, but the multi-core / same-core dummy_check passes are
+        # supposed to split every consumer down to a single producer column. If one
+        # survives, the graph is malformed for tagging -- fail loudly.
+        multi_check = sorted(v.node_id for v, c in check_edge_count.items() if c > 1)
+        if multi_check:
             raise NotImplementedError(
-                "dep-tag allocation: multi-target set/check ops (e.g. broadcast "
-                f"dep_set) need shared reserved tags; not yet supported: {multi}")
+                "dep-tag allocation: a dep_check op drains multiple producer edges "
+                f"(needs HW broadcast-check); not supported: {multi_check}")
+
+        # Broadcast groups: a set node driving >1 set->check edge. Its single
+        # dep_set_tag must cover one (cluster, R, C) position replicated across the
+        # distinct target chiplets, so verify the edges form exactly that shape.
+        cell_of = lambda u, v: (v.assigned_chiplet_id, v.assigned_cluster_id,
+                                v.assigned_core_id, u.assigned_core_id)
+        bcast = {u: el for u, el in set_edges.items() if len(el) > 1}
+        for u, el in bcast.items():
+            positions = {(v.assigned_cluster_id, v.assigned_core_id, u.assigned_core_id)
+                         for (_u, v) in el}
+            landing = {cell_of(_u, v) for (_u, v) in el}
+            if len(positions) != 1 or len(landing) != len(el):
+                raise NotImplementedError(
+                    f"dep-tag allocation: multi-target dep_set op {u.node_id} is not "
+                    "a uniform per-chiplet broadcast (its edges must share one "
+                    "(cluster, R, C) and land on distinct chiplets); a single shared "
+                    "tag cannot represent it.")
+
+        # Reserve one tag per broadcast group. Two groups that land in a common cell
+        # must differ -> greedy-colour them on the share-a-cell conflict graph.
+        bcast_landing = {u: {cell_of(_u, v) for (_u, v) in el} for u, el in bcast.items()}
+        reserved: dict = {}                   # broadcast set_node -> reserved tag
+        for u in sorted(bcast, key=lambda n: n.node_id):
+            taken = {reserved[w] for w in reserved
+                     if bcast_landing[w] & bcast_landing[u]}
+            tag = next((t for t in range(max_tags) if t not in taken), None)
+            if tag is None:
+                raise ValueError(
+                    "dep-tag allocation: too many broadcast groups share a cell for "
+                    f"tag_width={tag_width}; widen DepTagWidth.")
+            reserved[u] = tag
+            u.dep_set_tag = tag
+            for (_u, v) in bcast[u]:
+                v.dep_check_tag = tag
 
         # Same-core HOL reachability: at runtime each core dispatches its tasks in
         # topological (= push) order, so a same-core node that comes later is
@@ -580,8 +637,8 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
             for i in range(len(seq) - 1):
                 hb.add_edge(seq[i], seq[i + 1])
 
-        for key, edges in cells.items():
-            edges.sort(key=lambda e: (pos[e[0]], pos[e[1]]))
+        def min_chain_cover(edges: list) -> dict:
+            """Map each edge index -> chain id (0-based) via min chain-cover."""
             n = len(edges)
             # reach[a] = nodes reachable from edge a's consumer (its drain point)
             reach = [nx.descendants(hb, cv) for (_su, cv) in edges]
@@ -594,10 +651,8 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
                         continue
                     # a precedes b (may share a tag) iff edge a's drain happens
                     # before edge b's set: they meet at one node (a's consumer IS
-                    # b's producer), b's producer is reachable from a's consumer,
-                    # or a's consumer and b's producer are on the SAME core (run
-                    # serially in topological = push = HOL dispatch order, which
-                    # collapses same-core diagonal cells with no explicit path).
+                    # b's producer), or b's producer is reachable from a's consumer
+                    # in the happens-before (incl. same-core HOL) order.
                     if edges[b][0] is edges[a][1] or edges[b][0] in reach[a]:
                         B.add_edge(("L", a), ("R", b))
             match = (nx.algorithms.bipartite.hopcroft_karp_matching(
@@ -607,26 +662,37 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
             for node, m in match.items():
                 if node[0] == "L":
                     succ[node[1]] = m[1]; has_pred.add(m[1])
-            tag_of, n_chains = {}, 0
+            chain_of, n_chains = {}, 0
             for a in range(n):
                 if a in has_pred:
                     continue                   # not a chain head
                 cur = a
                 while True:
-                    tag_of[cur] = n_chains
-                    if cur in succ:
-                        cur = succ[cur]
-                    else:
+                    chain_of[cur] = n_chains
+                    cur = succ.get(cur)
+                    if cur is None:
                         break
                 n_chains += 1
-            if n_chains > max_tags:
+            return chain_of
+
+        for key, all_edges in cells.items():
+            # Broadcast edges already carry their reserved tag; chain-cover only the
+            # local (single-edge) producers, drawing tags from the pool MINUS the
+            # reserved tags of any broadcast that also lands in this cell.
+            edges = [(u, v) for (u, v) in all_edges if u not in bcast]
+            skip = {reserved[u] for (u, _v) in all_edges if u in bcast}
+            avail = [t for t in range(max_tags) if t not in skip]
+            edges.sort(key=lambda e: (pos[e[0]], pos[e[1]]))
+            chain_of = min_chain_cover(edges)
+            n_chains = len(set(chain_of.values())) if chain_of else 0
+            if n_chains > len(avail):
                 raise ValueError(
-                    f"dep-tag allocation: cell {key} needs {n_chains} > {max_tags} "
-                    f"concurrent tags (tag_width={tag_width}); reduce this cell's "
-                    f"concurrency in placement or widen DepTagWidth.")
+                    f"dep-tag allocation: cell {key} needs {n_chains} local + "
+                    f"{len(skip)} reserved > {max_tags} tags (tag_width={tag_width}); "
+                    f"reduce this cell's concurrency in placement or widen DepTagWidth.")
             for i, (su, cv) in enumerate(edges):
-                su.dep_set_tag = tag_of[i]
-                cv.dep_check_tag = tag_of[i]
+                su.dep_set_tag = avail[chain_of[i]]
+                cv.dep_check_tag = avail[chain_of[i]]
 
     # ----------------------------------------------------------------
     # DARTS Tier 1: Conditional Execution Compilation

--- a/target/sw/host/runtime/libbingo/mini_compiler/bingo_dfg.py
+++ b/target/sw/host/runtime/libbingo/mini_compiler/bingo_dfg.py
@@ -403,6 +403,97 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
                     dummy_check_node.remote_dep_set_all = False
                     self.bingo_insert_node_between(pred, cur_node, dummy_check_node)
 
+    def bingo_transform_dfg_serialize_shared_counter_consumers(self) -> None:
+        """Serialize producers that feed a SHARED dependency-matrix counter cell.
+
+        Corner case
+        -----------
+        The dependency matrix holds one 8-bit *counter* per
+        ``(consumer_core, producer_core)`` pair, and a ``dep_check`` passes as
+        soon as ``counter[R][C] >= 1`` -- it knows the COUNT of pending signals
+        from core ``C``, not WHICH producer raised them. When two or more normal
+        consumers sit on the SAME core ``R`` and each waits (cross-core) on the
+        SAME producer core ``C``, they all check the SAME cell ``counter[R][C]``,
+        and every producer feeding any of them increments that one cell. A
+        consumer can then drain a *different* consumer's producer increment and
+        dispatch before its own input is actually ready.
+
+        Example: consumer A needs producers {a1 (early), a2 (late)} and consumer
+        B needs {b1 (early)}. All three increment ``counter[R][C]``; A's two
+        checks pass on the two EARLY increments (a1, b1) instead of (a1, a2), so
+        A dispatches before a2 has completed and reads stale data.
+
+        Fix
+        ---
+        Order the producers so each consumer's producers complete before the
+        next consumer's, matching the consumers' queue (topological) order.
+        Because the producers all live on the same core ``C``, this is a pure
+        queue-order / head-of-line serialization (same-core edges, no extra
+        cross-core counter traffic): add an edge from every earlier-consumer
+        producer to every later-consumer producer (skipping shared producers and
+        any edge that would create a cycle). The shared counter then accumulates
+        each consumer's increments contiguously and in order, so every consumer
+        drains exactly its own producers' signals.
+
+        MUST run BEFORE ``bingo_transform_add_core_sequencing_edges`` (and the
+        dummy_set / dummy_check passes): the per-core sequencing chains same-core
+        nodes in topological order, so the producer ordering added here is then
+        honored by the sequencing instead of conflicting with it.
+        """
+        topo = list(nx.topological_sort(self))
+        pos = {n: i for i, n in enumerate(topo)}
+        # (consumer_core R, producer_core C) -> [(consumer, [its producers on core C]), ...]
+        cells: dict = {}
+        for con in self.node_list:
+            if con.node_type != "normal":
+                continue
+            R = con.assigned_core_id
+            prods_by_core: dict = {}
+            for pred in self.predecessors(con):
+                if pred.assigned_core_id != R:                 # cross-core producer
+                    prods_by_core.setdefault(pred.assigned_core_id, []).append(pred)
+            for C, prods in prods_by_core.items():
+                # The dependency matrix is PER (chiplet, cluster): a consumer on
+                # cluster K checks that cluster's own counter[R][C], so only
+                # consumers on the SAME (chiplet, cluster) actually share a cell.
+                cells.setdefault((con.assigned_chiplet_id, con.assigned_cluster_id, R, C),
+                                 []).append((con, prods))
+
+        for (chip, cl, R, C), entries in cells.items():
+            if len(entries) < 2:                               # cell not shared -> nothing to do
+                continue
+            entries.sort(key=lambda e: pos[e[0]])              # consumers in queue (topo) order
+            for i in range(1, len(entries)):
+                prev_prods, cur_prods = entries[i - 1][1], entries[i][1]
+                for cp in cur_prods:
+                    for pp in prev_prods:
+                        if pp is cp or self.has_edge(pp, cp):
+                            continue
+                        if nx.has_path(self, cp, pp):
+                            # cp is already sequenced BEFORE pp on its core (a
+                            # pre-existing same-core chain orders cp ... pp). Adding
+                            # pp -> cp would cycle, so re-splice: cut cp's same-core
+                            # successor edge that leads to pp (pure sequencing -- cp's
+                            # data goes cross-core to its consumer), freeing cp; the
+                            # freed successor is re-sequenced by the later core
+                            # sequencing pass. Then order cp after pp below.
+                            succ = next((s for s in self.successors(cp)
+                                         if s.assigned_core_id == cp.assigned_core_id
+                                         and (s is pp or nx.has_path(self, s, pp))), None)
+                            if succ is None:
+                                continue                       # cannot safely reorder
+                            self.remove_edge(cp, succ)
+                            if nx.has_path(self, cp, pp):
+                                # another path still orders cp before pp: reordering
+                                # would cycle. Restore and leave this pair as-is.
+                                self.add_edge(cp, succ)
+                                continue
+                        self.add_edge(pp, cp)
+                        print(f"Serializing shared counter[c{chip}.{cl}][{R}][{C}]: "
+                              f"{pp.node_name} -> {cp.node_name} (producer of "
+                              f"'{entries[i-1][0].node_name}' before producer of "
+                              f"'{entries[i][0].node_name}')")
+
     def bingo_transform_add_core_sequencing_edges(self) -> int:
         """Add edges between consecutive tasks on the same core.
 
@@ -1856,6 +1947,10 @@ class BingoDFG(DiGraphWrapper[BingoNode]):
         # No-op for non-conditional DFGs (returns empty dict).
         self.bingo_compile_conditional_regions()
         self._validate_cerf_cross_group_edges()
+        # Serialize producers that share a (consumer_core, producer_core) counter cell
+        # across multiple consumers. MUST run before core sequencing so the producer
+        # ordering it adds is reflected in the topological sort used for sequencing.
+        self.bingo_transform_dfg_serialize_shared_counter_consumers()
         # Add Dummy Set/Check Nodes
         self.bingo_transform_add_core_sequencing_edges()
         self.bingo_transform_dfg_add_dummy_set_nodes()

--- a/target/sw/host/runtime/libbingo/mini_compiler/bingo_node.py
+++ b/target/sw/host/runtime/libbingo/mini_compiler/bingo_node.py
@@ -38,6 +38,10 @@ class BingoNode(metaclass=ABCMeta):
         self._dep_set_list: list[int] = []
         self._dep_set_chiplet_id: int = 0
         self._dep_set_cluster_id: int = 0
+        # Per-edge identity tags (EnableTaggedDeps). None until the tag-allocator
+        # pass runs; packed as 0 otherwise so untagged descriptors are unchanged.
+        self._dep_check_tag: int | None = None
+        self._dep_set_tag: int | None = None
         # DARTS Tier 1: Conditional Execution
         self._cond_exec_en: bool = False
         self._cond_exec_group_id: int = 0
@@ -179,6 +183,22 @@ class BingoNode(metaclass=ABCMeta):
     @dep_set_cluster_id.setter
     def dep_set_cluster_id(self, value: int) -> None:
         self._dep_set_cluster_id = value
+
+    @property
+    def dep_check_tag(self) -> int | None:
+        return self._dep_check_tag
+
+    @dep_check_tag.setter
+    def dep_check_tag(self, value: int | None) -> None:
+        self._dep_check_tag = value
+
+    @property
+    def dep_set_tag(self) -> int | None:
+        return self._dep_set_tag
+
+    @dep_set_tag.setter
+    def dep_set_tag(self, value: int | None) -> None:
+        self._dep_set_tag = value
 
     @property
     def cond_exec_en(self) -> bool:


### PR DESCRIPTION
## Summary

This branch updates the bingo **mini-compiler** so the mini-compiler drives the new hw scheduler, adding broadcast-aware dependency-tag allocation and related DFG/node improvements.

The hw scheduler is already pushed to the main branch. The RTL changes sit in https://github.com/KULeuven-MICAS/bingo_hw_manager on adding the tag info at the dep matrix. 

## Changes

### `bingo_dfg.py` — DFG / dependency-tag scheduling

- **Serialized shared-counter pass** for the dependency graph.
- **Broadcast-aware dep-tag allocation.** Dependency tags are now allocated via a minimum
  chain-cover per physical cell; broadcast set→check groups reserve a single shared tag
  across their target chiplets, and local single-edge producers draw from the remaining
  pool. Two broadcast groups that land in a common cell get distinct tags (greedy
  colouring on the share-a-cell conflict).
- **Broadcast guard** (`num_chiplets > 2`): a single point-to-point remote edge is no
  longer mis-flagged as a broadcast (which would multicast `AW=0xFF` to every chiplet and
  leave a stray tagged set with no consumer); such an edge uses a targeted dummy-set.
- General DFG cleanups.

### `bingo_node.py`

- Node-model updates supporting the new dep-tag allocation.

### `bingo_api.h` / `bingo_utils.h`

- API and utility updates to match the new hw scheduler.

## Notes

- All touched mini-compiler modules pass `py_compile`.
- The HW scheduler's updates are default to open from the paramater
    parameter bit          EnableTaggedDeps = 1'b1,
    parameter int unsigned DepTagWidth = 4,
   So we do not have to touch the wrappers on the rtl level. This will be improved with the following PRs

- All local ci passes. I will later add more complex workloads to stress test the HW Scheduler.