### PR TITLE
CI: run local_ci at the tapeout cfg's real 128 KiB spm_wide

### DIFF
--- a/target/sim/automation/ci/local_ci/tapeout/run_local_ci.py
+++ b/target/sim/automation/ci/local_ci/tapeout/run_local_ci.py
@@ -16,16 +16,15 @@ run directories, so the suites do not clobber each other:
     tapeout_2c/       hemaia_tapeout_2c.hjson        2x versacore 256KB
     tapeout_2c_simd/  hemaia_tapeout_2c_simd.hjson   2x versacore 256KB+SIMD
 
-The runner sets ``use_vendor_pll: false`` and a 16 MiB ``spm_wide`` in the cfg
-before building (see ``resolve_rtl_cfg``); the patched copy lands in
-``target/rtl/cfg/generated/``.
+The runner sets ``use_vendor_pll: false`` in the cfg before building (see
+``resolve_rtl_cfg``); the patched copy lands in ``target/rtl/cfg/generated/``.
+The suite builds against the cfg's own ``spm_wide`` (the tapeout's real 128 kiB).
 
 Defaults to the VCS engine with no waveform (fast batch runs); pass
 ``--engine vsim --waveform 1`` to reproduce a failing task under Questasim.
 
     python3 run_local_ci.py [-j JOBS] [-f task.yaml] [--cfg CFG] [--engine vcs|vsim]
                             [--waveform 0|1] [--no-d2d] [--no-macro]
-                            [--spm-wide-size BYTES]
 """
 
 from __future__ import annotations
@@ -45,10 +44,6 @@ from hemaia_sim_runner import (  # noqa: E402
 CI_CFG = "target/rtl/cfg/hemaia_tapeout.hjson"
 SIM_CFG = "target/sim/cfg/sim_rtl.hjson"
 DEFAULT_TASK_YAML = "task_local_ci.yaml"
-# The tapeout's real 128 kiB spm_wide is too small for this suite: the
-# gemm-msplit-4cluster-1chip .devicebin alone overflows WIDE_SPM by ~1.9 MiB.
-# Give the simulation a 16 MiB scratchpad instead.
-DEFAULT_SPM_WIDE_SIZE = 16 * 1024 * 1024
 
 
 def parse_args() -> argparse.Namespace:
@@ -74,10 +69,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--macro", action=argparse.BooleanOptionalAction, default=True,
         help="init the tech_cells_tsmc16 private module (use --no-macro for the single-chip flow).")
-    parser.add_argument(
-        "--spm-wide-size", type=int, default=DEFAULT_SPM_WIDE_SIZE,
-        help="spm_wide.length in bytes, patched into the cfg (default: %(default)s = 16 MiB). "
-             "Pass 0 to keep the cfg's own value (the tapeout's real 128 kiB).")
     args = parser.parse_args()
     if args.max_sim_jobs < 1:
         parser.error("--max-sim-jobs must be >= 1")
@@ -101,7 +92,6 @@ def main() -> None:
         with_macro=args.macro,
         with_d2d=args.d2d,
         with_pll=False,
-        spm_wide_size=args.spm_wide_size or None,
         max_jobs=args.max_sim_jobs,
     )
     runner.run(parse_tasks(task_yaml))

--- a/target/sim/automation/ci/local_ci/tapeout_1c_simd/run_local_ci.py
+++ b/target/sim/automation/ci/local_ci/tapeout_1c_simd/run_local_ci.py
@@ -16,16 +16,15 @@ run directories, so the suites do not clobber each other:
     tapeout_2c/       hemaia_tapeout_2c.hjson        2x versacore 256KB
     tapeout_2c_simd/  hemaia_tapeout_2c_simd.hjson   2x versacore 256KB+SIMD
 
-The runner sets ``use_vendor_pll: false`` and a 16 MiB ``spm_wide`` in the cfg
-before building (see ``resolve_rtl_cfg``); the patched copy lands in
-``target/rtl/cfg/generated/``.
+The runner sets ``use_vendor_pll: false`` in the cfg before building (see
+``resolve_rtl_cfg``); the patched copy lands in ``target/rtl/cfg/generated/``.
+The suite builds against the cfg's own ``spm_wide`` (the tapeout's real 128 kiB).
 
 Defaults to the VCS engine with no waveform (fast batch runs); pass
 ``--engine vsim --waveform 1`` to reproduce a failing task under Questasim.
 
     python3 run_local_ci.py [-j JOBS] [-f task.yaml] [--cfg CFG] [--engine vcs|vsim]
                             [--waveform 0|1] [--no-d2d] [--no-macro]
-                            [--spm-wide-size BYTES]
 """
 
 from __future__ import annotations
@@ -45,10 +44,6 @@ from hemaia_sim_runner import (  # noqa: E402
 CI_CFG = "target/rtl/cfg/hemaia_tapeout_1c_simd.hjson"
 SIM_CFG = "target/sim/cfg/sim_rtl.hjson"
 DEFAULT_TASK_YAML = "task_local_ci.yaml"
-# The tapeout's real 128 kiB spm_wide is too small for parts of the SW tree
-# (a ~2 MiB .devicebin overflows WIDE_SPM at link time). Give the simulation a
-# 16 MiB scratchpad instead; pass --spm-wide-size 0 to run the real 128 kiB.
-DEFAULT_SPM_WIDE_SIZE = 16 * 1024 * 1024
 
 
 def parse_args() -> argparse.Namespace:
@@ -74,10 +69,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--macro", action=argparse.BooleanOptionalAction, default=True,
         help="init the tech_cells_tsmc16 private module (use --no-macro for the single-chip flow).")
-    parser.add_argument(
-        "--spm-wide-size", type=int, default=DEFAULT_SPM_WIDE_SIZE,
-        help="spm_wide.length in bytes, patched into the cfg (default: %(default)s = 16 MiB). "
-             "Pass 0 to keep the cfg's own value (the tapeout's real 128 kiB).")
     args = parser.parse_args()
     if args.max_sim_jobs < 1:
         parser.error("--max-sim-jobs must be >= 1")
@@ -101,7 +92,6 @@ def main() -> None:
         with_macro=args.macro,
         with_d2d=args.d2d,
         with_pll=False,
-        spm_wide_size=args.spm_wide_size or None,
         max_jobs=args.max_sim_jobs,
     )
     runner.run(parse_tasks(task_yaml))

--- a/target/sim/automation/ci/local_ci/tapeout_2c/run_local_ci.py
+++ b/target/sim/automation/ci/local_ci/tapeout_2c/run_local_ci.py
@@ -16,16 +16,15 @@ run directories, so the suites do not clobber each other:
     tapeout_2c/       hemaia_tapeout_2c.hjson        2x versacore 256KB
     tapeout_2c_simd/  hemaia_tapeout_2c_simd.hjson   2x versacore 256KB+SIMD
 
-The runner sets ``use_vendor_pll: false`` and a 16 MiB ``spm_wide`` in the cfg
-before building (see ``resolve_rtl_cfg``); the patched copy lands in
-``target/rtl/cfg/generated/``.
+The runner sets ``use_vendor_pll: false`` in the cfg before building (see
+``resolve_rtl_cfg``); the patched copy lands in ``target/rtl/cfg/generated/``.
+The suite builds against the cfg's own ``spm_wide`` (the tapeout's real 128 kiB).
 
 Defaults to the VCS engine with no waveform (fast batch runs); pass
 ``--engine vsim --waveform 1`` to reproduce a failing task under Questasim.
 
     python3 run_local_ci.py [-j JOBS] [-f task.yaml] [--cfg CFG] [--engine vcs|vsim]
                             [--waveform 0|1] [--no-d2d] [--no-macro]
-                            [--spm-wide-size BYTES]
 """
 
 from __future__ import annotations
@@ -45,10 +44,6 @@ from hemaia_sim_runner import (  # noqa: E402
 CI_CFG = "target/rtl/cfg/hemaia_tapeout_2c.hjson"
 SIM_CFG = "target/sim/cfg/sim_rtl.hjson"
 DEFAULT_TASK_YAML = "task_local_ci.yaml"
-# The tapeout's real 128 kiB spm_wide is too small for parts of the SW tree
-# (a ~2 MiB .devicebin overflows WIDE_SPM at link time). Give the simulation a
-# 16 MiB scratchpad instead; pass --spm-wide-size 0 to run the real 128 kiB.
-DEFAULT_SPM_WIDE_SIZE = 16 * 1024 * 1024
 
 
 def parse_args() -> argparse.Namespace:
@@ -74,10 +69,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--macro", action=argparse.BooleanOptionalAction, default=True,
         help="init the tech_cells_tsmc16 private module (use --no-macro for the single-chip flow).")
-    parser.add_argument(
-        "--spm-wide-size", type=int, default=DEFAULT_SPM_WIDE_SIZE,
-        help="spm_wide.length in bytes, patched into the cfg (default: %(default)s = 16 MiB). "
-             "Pass 0 to keep the cfg's own value (the tapeout's real 128 kiB).")
     args = parser.parse_args()
     if args.max_sim_jobs < 1:
         parser.error("--max-sim-jobs must be >= 1")
@@ -101,7 +92,6 @@ def main() -> None:
         with_macro=args.macro,
         with_d2d=args.d2d,
         with_pll=False,
-        spm_wide_size=args.spm_wide_size or None,
         max_jobs=args.max_sim_jobs,
     )
     runner.run(parse_tasks(task_yaml))

--- a/target/sim/automation/ci/local_ci/tapeout_2c_simd/run_local_ci.py
+++ b/target/sim/automation/ci/local_ci/tapeout_2c_simd/run_local_ci.py
@@ -16,16 +16,15 @@ run directories, so the suites do not clobber each other:
     tapeout_2c/       hemaia_tapeout_2c.hjson        2x versacore 256KB
     tapeout_2c_simd/  hemaia_tapeout_2c_simd.hjson   2x versacore 256KB+SIMD
 
-The runner sets ``use_vendor_pll: false`` and a 16 MiB ``spm_wide`` in the cfg
-before building (see ``resolve_rtl_cfg``); the patched copy lands in
-``target/rtl/cfg/generated/``.
+The runner sets ``use_vendor_pll: false`` in the cfg before building (see
+``resolve_rtl_cfg``); the patched copy lands in ``target/rtl/cfg/generated/``.
+The suite builds against the cfg's own ``spm_wide`` (the tapeout's real 128 kiB).
 
 Defaults to the VCS engine with no waveform (fast batch runs); pass
 ``--engine vsim --waveform 1`` to reproduce a failing task under Questasim.
 
     python3 run_local_ci.py [-j JOBS] [-f task.yaml] [--cfg CFG] [--engine vcs|vsim]
                             [--waveform 0|1] [--no-d2d] [--no-macro]
-                            [--spm-wide-size BYTES]
 """
 
 from __future__ import annotations
@@ -45,10 +44,6 @@ from hemaia_sim_runner import (  # noqa: E402
 CI_CFG = "target/rtl/cfg/hemaia_tapeout_2c_simd.hjson"
 SIM_CFG = "target/sim/cfg/sim_rtl.hjson"
 DEFAULT_TASK_YAML = "task_local_ci.yaml"
-# The tapeout's real 128 kiB spm_wide is too small for parts of the SW tree
-# (a ~2 MiB .devicebin overflows WIDE_SPM at link time). Give the simulation a
-# 16 MiB scratchpad instead; pass --spm-wide-size 0 to run the real 128 kiB.
-DEFAULT_SPM_WIDE_SIZE = 16 * 1024 * 1024
 
 
 def parse_args() -> argparse.Namespace:
@@ -74,10 +69,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--macro", action=argparse.BooleanOptionalAction, default=True,
         help="init the tech_cells_tsmc16 private module (use --no-macro for the single-chip flow).")
-    parser.add_argument(
-        "--spm-wide-size", type=int, default=DEFAULT_SPM_WIDE_SIZE,
-        help="spm_wide.length in bytes, patched into the cfg (default: %(default)s = 16 MiB). "
-             "Pass 0 to keep the cfg's own value (the tapeout's real 128 kiB).")
     args = parser.parse_args()
     if args.max_sim_jobs < 1:
         parser.error("--max-sim-jobs must be >= 1")
@@ -101,7 +92,6 @@ def main() -> None:
         with_macro=args.macro,
         with_d2d=args.d2d,
         with_pll=False,
-        spm_wide_size=args.spm_wide_size or None,
         max_jobs=args.max_sim_jobs,
     )
     runner.run(parse_tasks(task_yaml))

--- a/target/sw/device/apps/snax/gemm-msplit-4cluster-1chip/data/datagen.py
+++ b/target/sw/device/apps/snax/gemm-msplit-4cluster-1chip/data/datagen.py
@@ -766,6 +766,15 @@ def emit_matmul_data(**kwargs):
     data_str += [format_scalar_definition("int32_t", "delta_local_c", delta_local_c)]
     data_str += [format_scalar_definition("int32_t", "delta_local_d", delta_local_d)]
 
+    # The on-device result check stages the golden D-block (DMA'd back from the
+    # memory chip) in the A/B TCDM region freed after the compute, starting at
+    # delta_local_a. That region must be at least one D-block wide.
+    assert delta_local_d >= d_data_length, (
+        "golden D-block does not fit in the freed A/B TCDM region",
+        delta_local_d,
+        d_data_length,
+    )
+
     # -----------------------------------------------------------
     # Test Data generation
     # -----------------------------------------------------------
@@ -843,48 +852,9 @@ def emit_matmul_data(**kwargs):
         A = np.random.randint(A_MIN, A_MAX, size=(M_full, K, meshRow, tileSize)).reshape(
             -1
         )
-        if a_len == 4:
-            data_str += [
-                format_vector_definition(
-                    "int8_t", "A_orginal_4bits", A, hex_bits=8, cast_hex=True
-                )
-            ]
-            A_packed = pack_signed_nbit(A, bit_width=4, pack_per_byte=2)
-            data_str += [
-                format_vector_definition(
-                    "int8_t", "A", A_packed, hex_bits=8, cast_hex=True
-                )
-            ]
-        elif a_len == 8:
-            data_str += [
-                format_vector_definition("int8_t", "A", A, hex_bits=8, cast_hex=True)
-            ]
-        elif a_len == 16:
-            data_str += [
-                format_vector_definition("int16_t", "A", A, hex_bits=16, cast_hex=True)
-            ]
-        else:
-            raise ValueError("Invalid A data type")
-
         B = np.random.randint(B_MIN, B_MAX, size=(K, N, tileSize, meshCol)).reshape(-1)
-        if b_len == 4:
-            data_str += [
-                format_vector_definition(
-                    "int8_t", "B_orginal_4bits", B, hex_bits=8, cast_hex=True
-                )
-            ]
-            B_packed = pack_signed_nbit(B, bit_width=4, pack_per_byte=2)
-            data_str += [
-                format_vector_definition(
-                    "int8_t", "B", B_packed, hex_bits=8, cast_hex=True
-                )
-            ]
-        elif b_len == 8:
-            data_str += [
-                format_vector_definition("int8_t", "B", B, hex_bits=8, cast_hex=True)
-            ]
-        else:
-            raise ValueError("Invalid B data type")
+        # A/B are not baked into the device binary; the device DMAs them from the
+        # memory-chip image (A_mem/B_mem) assembled below.
 
         if enable_full_C == 1:
             C = np.random.randint(
@@ -894,9 +864,7 @@ def emit_matmul_data(**kwargs):
             C = np.random.randint(0, 1, size=(M_full, N, meshRow, meshCol)).reshape(-1)
 
         assert c_len == 32, "C data type must be 32 bits for now"
-        data_str += [
-            format_vector_definition("int32_t", "C", C, hex_bits=32, cast_hex=True)
-        ]
+        # C is not baked into the device binary (unused by this workload).
 
     # Snapshot the PRE-transpose A and B: these raw bytes are what the device
     # DMAs out of the memory chip, and the versacore transpose units re-apply
@@ -955,9 +923,8 @@ def emit_matmul_data(**kwargs):
             subtraction_b,
             C,
         )
-        data_str += [
-            format_vector_definition("int32_t", "D", D, hex_bits=32, cast_hex=True)
-        ]
+        # D (golden) is not baked into the device binary; it is written into the
+        # memory-chip image below and DMA'd back for the on-device result check.
 
     data_str += [format_scalar_definition("int32_t", "set_addr_remap_index_A", 0)]
     data_str += [format_scalar_definition("int32_t", "set_addr_remap_index_B", 0)]
@@ -977,30 +944,9 @@ def emit_matmul_data(**kwargs):
     data_str += [format_scalar_definition("int32_t", "input_zp_i", input_zp_i)]
     data_str += [format_scalar_definition("int32_t", "output_zp_i", output_zp_i)]
 
-    output_matrix = []
-
-    for data_element in D:
-        output_matrix.append(
-            # V3 Holds the approximation of the TOSA.Rescale operation.
-            # use V2 for the exact model
-            postprocessing_simd_golden_model_V3(
-                data_element,
-                input_zp_i,
-                output_zp_i,
-                shift_i,
-                max_in_range,
-                -max_in_range,
-                True,
-                multiplier,
-            )
-        )
-    output_matrix = np.array(output_matrix, dtype=np.uint8)
-
-    data_str += [
-        format_vector_definition(
-            "int8_t", "D_quantized", output_matrix, hex_bits=8, cast_hex=True
-        )
-    ]
+    # D_quantized / D_int32tofp16 reference outputs are intentionally NOT baked
+    # into the device binary; this workload's result check compares the int32 D
+    # golden fetched from the memory chip (see the mempool image below).
 
     # Int32 to FP16 conversion
     data_str += [
@@ -1013,25 +959,14 @@ def emit_matmul_data(**kwargs):
         kwargs["quantization_enable"] + kwargs["int32tofp16_enable"] <= 1
     ), "Only one of quantization and int32 to fp16 conversion can be enabled."
 
-    fp_output_matrix = []
-
-    for data_element in D:
-        fp_output_matrix.append(int32_to_fp16_golden(data_element))
-    fp_output_matrix = np.array(fp_output_matrix, dtype=np.uint16)
-
-    data_str += [
-        format_vector_definition(
-            "int16_t", "D_int32tofp16", fp_output_matrix, hex_bits=16, cast_hex=True
-        )
-    ]
-
     # -----------------------------------------------------------
     # Memory-chip image (mempool.bin) + layout offsets
     # -----------------------------------------------------------
     # The memory chip holds, in order: the shared B matrix, then the
-    # num_clusters A row-blocks, then a zeroed D region (one block per cluster).
-    # The device writes its computed D-block back here. Region starts are
-    # 64-byte aligned.
+    # num_clusters A row-blocks, then a zeroed compute-D region (one block per
+    # cluster, which the device fills with its computed output), then the golden
+    # D region (one block per cluster) the device DMAs back for the on-device
+    # result check. Region starts are 64-byte aligned.
     def _align64(value):
         return (int(value) + 63) // 64 * 64
 
@@ -1043,7 +978,8 @@ def emit_matmul_data(**kwargs):
     mem_off_B = 0
     mem_off_A_base = _align64(mem_off_B + b_total_bytes)
     mem_off_D_base = _align64(mem_off_A_base + num_clusters * a_block_bytes)
-    image_bytes = mem_off_D_base + num_clusters * d_block_bytes
+    mem_off_D_golden = _align64(mem_off_D_base + num_clusters * d_block_bytes)
+    image_bytes = mem_off_D_golden + num_clusters * d_block_bytes
 
     data_str += [
         format_scalar_definition("uint64_t", "mem_chip_local_base", mem_chip_local_base)
@@ -1051,19 +987,28 @@ def emit_matmul_data(**kwargs):
     data_str += [format_scalar_definition("uint32_t", "mem_off_B", mem_off_B)]
     data_str += [format_scalar_definition("uint32_t", "mem_off_A_base", mem_off_A_base)]
     data_str += [format_scalar_definition("uint32_t", "mem_off_D_base", mem_off_D_base)]
+    data_str += [
+        format_scalar_definition("uint32_t", "mem_off_D_golden", mem_off_D_golden)
+    ]
 
     b_image = B_mem.tobytes()
     a_image = A_mem.tobytes()
+    d_golden_image = np.asarray(D, dtype=np.int32).tobytes()
     assert len(b_image) == b_total_bytes, (len(b_image), b_total_bytes)
     assert len(a_image) == num_clusters * a_block_bytes, (
         len(a_image),
         num_clusters * a_block_bytes,
     )
+    assert len(d_golden_image) == num_clusters * d_block_bytes, (
+        len(d_golden_image),
+        num_clusters * d_block_bytes,
+    )
 
     image = bytearray(image_bytes)
     image[mem_off_B : mem_off_B + b_total_bytes] = b_image
     image[mem_off_A_base : mem_off_A_base + len(a_image)] = a_image
-    # The D region stays zero-initialised; the device fills it at run time.
+    image[mem_off_D_golden : mem_off_D_golden + len(d_golden_image)] = d_golden_image
+    # The compute-D region stays zero-initialised; the device fills it at run time.
 
     out_dir = pathlib.Path(kwargs.get("out_dir", os.path.dirname(__file__)))
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/target/sw/device/apps/snax/gemm-msplit-4cluster-1chip/src/gemm-msplit-4cluster-1chip.c
+++ b/target/sw/device/apps/snax/gemm-msplit-4cluster-1chip/src/gemm-msplit-4cluster-1chip.c
@@ -187,10 +187,26 @@ int main() {
 #if GEMM_MSPLIT_CHECK_RESULT
     // Check each cluster's D-block in parallel. Keep this silent so only the
     // summary prints below need serialization.
+    //
+    // The golden D lives on the memory chip (mem_off_D_golden), not baked into
+    // the device binary. The DM core DMAs this cluster's golden D-block into the
+    // TCDM region freed after the compute (the A/B staging area at
+    // delta_local_a, sized >= one D-block by the datagen), then core 0 compares
+    // it against the computed D-block.
+    uint64_t mem_d_golden = chiplet_addr_transform_loc(
+        MEM_CHIP_LOC_X, MEM_CHIP_LOC_Y,
+        (uint64_t)mem_chip_local_base + mem_off_D_golden +
+            (uint64_t)block * (uint32_t)d_data_length);
+    int8_t* golden = (int8_t*)(base + delta_local_a);
+    if (is_active_cluster && snrt_is_dm_core()) {
+        snrt_dma_start_1d_wideptr(
+            chiplet_addr_transform((uint64_t)(uintptr_t)golden), mem_d_golden,
+            d_data_length);
+        snrt_dma_wait_all();
+    }
+    snrt_cluster_hw_barrier();
     if (is_active_cluster && snrt_cluster_core_idx() == 0) {
         int8_t* output = (int8_t*)local_d;
-        int8_t* golden =
-            (int8_t*)((int32_t*)D + block * (M_block * N * meshRow * meshCol));
         for (int32_t i = 0; i < d_data_length; i++) {
             if (output[i] != golden[i]) {
                 err++;

--- a/util/automation_scripts/hemaia_sim_runner.py
+++ b/util/automation_scripts/hemaia_sim_runner.py
@@ -23,8 +23,6 @@ The flows differ only by parameters captured on :class:`HeMAiASimRunner`:
   * ``with_macro`` / ``with_d2d``   -- private vendor modules
   * ``with_pll``     -- the vendor PLL: selects the private clk/rst controller
     *and* sets ``use_vendor_pll`` in the RTL cfg (see :func:`resolve_rtl_cfg`)
-  * ``spm_wide_size``-- sets ``spm_wide.length`` in the RTL cfg, sizing the
-    ``WIDE_SPM`` region a simulation gets
 
 The ``engine`` is reduced to a small lookup (:data:`ENGINES`) of the make
 targets and artefacts that differ between the simulators; everything else is
@@ -148,12 +146,11 @@ def resolve_rtl_cfg(
     cfg: str,
     *,
     with_pll: bool,
-    spm_wide_size: Optional[int] = None,
 ) -> str:
     """Return the repo-relative RTL cfg to pass as ``CFG_OVERRIDE``.
 
-    A flow names a tapeout cfg and states the two fields a simulation may need to
-    differ on; this reconciles them:
+    A flow names a tapeout cfg and states the ``with_pll`` field a simulation may
+    need to differ on; this reconciles it:
 
     * ``with_pll`` is the single source of truth for the vendor PLL.  It selects
       the private clk/rst controller in ``Bender.local``, and it must agree with
@@ -161,10 +158,6 @@ def resolve_rtl_cfg(
       ``hemaia_clk_rst_controller`` unconditionally, so a cfg claiming
       ``use_vendor_pll: true`` under ``with_pll=False`` elaborates the *public*
       module with ``USE_VENDOR_PLL(1)``.
-    * ``spm_wide_size`` (bytes, ``None`` = leave the cfg alone) sets
-      ``spm_wide.length``, i.e. the ``WIDE_SPM`` region in ``host.ld``.  128 kiB
-      is too small for parts of the SW tree -- a 2 MiB ``.devicebin`` and the gemm
-      sweep's ``D_cfg`` tables overflow it at link time.
 
     A cfg that already matches on every requested field is returned untouched; a
     patched copy is only written when something actually differs, so flows that
@@ -178,9 +171,6 @@ def resolve_rtl_cfg(
     if bool(cfg_dict.get("use_vendor_pll", False)) != with_pll:
         cfg_dict["use_vendor_pll"] = with_pll
         suffixes.append("pll" if with_pll else "nopll")
-    if spm_wide_size is not None and cfg_dict["spm_wide"]["length"] != spm_wide_size:
-        cfg_dict["spm_wide"]["length"] = spm_wide_size
-        suffixes.append(f"spm{spm_wide_size // 1024}k")
 
     if not suffixes:
         return cfg
@@ -567,7 +557,6 @@ class HeMAiASimRunner:
         with_macro: bool,
         with_d2d: bool,
         with_pll: bool,
-        spm_wide_size: Optional[int] = None,
         max_jobs: int = DEFAULT_MAX_SIM_JOBS,
         docker_image: str = DEFAULT_DOCKER_IMAGE,
         in_container: bool = False,
@@ -587,14 +576,12 @@ class HeMAiASimRunner:
         self.cfg = cfg              # repo-relative RTL cfg as requested
         # The cfg actually handed to make as CFG_OVERRIDE.  ``run()`` re-resolves
         # it through resolve_rtl_cfg(), which derives a patched copy when the cfg
-        # disagrees with ``with_pll`` / ``spm_wide_size``.
+        # disagrees with ``with_pll``.
         self.effective_cfg = cfg
         self.sim_cfg = sim_cfg      # repo-relative sim cfg
         self.with_macro = with_macro
         self.with_d2d = with_d2d
         self.with_pll = with_pll
-        # spm_wide.length (bytes) to patch into the cfg; None = keep the cfg's own.
-        self.spm_wide_size = spm_wide_size
         self.max_jobs = max_jobs
         self.docker_image = docker_image
         # Optional flow switches (e.g. the git CI runs inside the build container
@@ -896,9 +883,7 @@ class HeMAiASimRunner:
         self.cleanup_stale_task_dirs()
 
         print(f"Engine: {self.engine}  waveform: {self.waveform}  cfg: {self.cfg}")
-        spm = "cfg" if self.spm_wide_size is None else f"{self.spm_wide_size // 1024} kiB"
-        print(f"  (macro={self.with_macro}, d2d={self.with_d2d}, pll={self.with_pll}, "
-              f"spm_wide={spm})")
+        print(f"  (macro={self.with_macro}, d2d={self.with_d2d}, pll={self.with_pll})")
 
         if self.skip_setup:
             print("[Step 1] Skipping reset/init (skip_setup)")
@@ -909,8 +894,7 @@ class HeMAiASimRunner:
         # Must run after Step 1: reset_and_init() calls ``make clean``, which wipes
         # the generated-cfg directory.
         self.effective_cfg = resolve_rtl_cfg(
-            self.repo_root, self.cfg,
-            with_pll=self.with_pll, spm_wide_size=self.spm_wide_size)
+            self.repo_root, self.cfg, with_pll=self.with_pll)
 
         if self.skip_build:
             print("[Step 2] Skipping SW/bootrom/RTL build (skip_build)")

--- a/util/occamygen/occamy.py
+++ b/util/occamygen/occamy.py
@@ -160,8 +160,8 @@ def unify_xdma_max_mem_size(occamy_cfg, cluster_cfg_paths):
     # `open(path, "w")` would truncate the SAME shared cluster hjson concurrently --
     # while sibling processes (get_cluster_cfg_list / generate_snitch) are reading it.
     # A reader landing mid-write gets a truncated file and dies with a parse error that
-    # points at a config nobody edited. It fires exactly when spm_wide.length changes,
-    # i.e. the local-CI `spm_wide_size` path.
+    # points at a config nobody edited. It fires whenever a cfg field feeding the
+    # unified cluster hjson changes between runs.
     #
     # write-temp-then-os.replace makes each write atomic: every writer produces byte
     # -identical content, and a reader always sees either the whole old file or the whole


### PR DESCRIPTION
The local_ci suites patched spm_wide up to 16 MiB before building, hiding the fact that the taped-out chip only has a 128 KiB WIDE_SPM. Remove the spm_wide override interface entirely so local_ci builds against each cfg's own L3:

- drop DEFAULT_SPM_WIDE_SIZE / --spm-wide-size from the 4 run_local_ci.py
- remove the spm_wide_size parameter from HeMAiASimRunner and resolve_rtl_cfg (and its docstrings/summary line); resolve_rtl_cfg now only reconciles with_pll / use_vendor_pll

Verified: `make sw` links every local_ci workload across all four tapeout cfgs at 128 KiB; the remaining WIDE_SPM overflows are apps that no local_ci suite runs.